### PR TITLE
Fix/include versions in steels

### DIFF
--- a/src/openepd/model/specs/concrete.py
+++ b/src/openepd/model/specs/concrete.py
@@ -372,7 +372,7 @@ class ConcreteV1Options(BaseOpenEpdSchema):
 class ReadyMixV1(BaseOpenEpdHierarchicalSpec):
     """Concretes to be mixed and then poured on-site."""
 
-    pass
+    _EXT_VERSION = "1.0"
 
 
 class FlowableFillV1(BaseOpenEpdHierarchicalSpec):
@@ -387,7 +387,7 @@ class FlowableFillV1(BaseOpenEpdHierarchicalSpec):
     under 1200 psi.
     """
 
-    pass
+    _EXT_VERSION = "1.0"
 
 
 class OilPatchV1(BaseOpenEpdHierarchicalSpec):
@@ -398,19 +398,19 @@ class OilPatchV1(BaseOpenEpdHierarchicalSpec):
     flowable fill and grout in that it contains no sand or other aggregates.
     """
 
-    pass
+    _EXT_VERSION = "1.0"
 
 
 class ConcretePavingV1(BaseOpenEpdHierarchicalSpec):
     """Concrete paving."""
 
-    pass
+    _EXT_VERSION = "1.0"
 
 
 class ShotcreteV1(BaseOpenEpdHierarchicalSpec):
     """Concretes sprayed on a target."""
 
-    pass
+    _EXT_VERSION = "1.0"
 
 
 class CementGroutV1(BaseOpenEpdHierarchicalSpec):
@@ -422,6 +422,8 @@ class CementGroutV1(BaseOpenEpdHierarchicalSpec):
     structural grout, these materials typically impart significant compressive strength to the system.
 
     """
+
+    _EXT_VERSION = "1.0"
 
 
 class ConcreteV1(BaseOpenEpdHierarchicalSpec):

--- a/src/openepd/model/specs/glass.py
+++ b/src/openepd/model/specs/glass.py
@@ -21,12 +21,13 @@ from enum import StrEnum
 
 import pydantic as pyd
 
+from openepd.model.base import BaseOpenEpdSchema
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
 from openepd.model.validation.numbers import PositiveInt, RatioFloat
 from openepd.model.validation.quantity import HeatConductanceUCIStr, LengthMmStr, PressureMPaStr, QuantityStr
 
 
-class SolarHeatGainMixin(BaseOpenEpdHierarchicalSpec):
+class SolarHeatGainMixin(BaseOpenEpdSchema):
     """Solar heat gain mixin."""
 
     solar_heat_gain: RatioFloat | None = pyd.Field(
@@ -38,7 +39,7 @@ class SolarHeatGainMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class GlazingOptionsMixin(BaseOpenEpdHierarchicalSpec):
+class GlazingOptionsMixin(BaseOpenEpdSchema):
     """Glazing options mixin."""
 
     low_emissivity: bool | None = pyd.Field(default=None, description="Low Emissivity coatings")
@@ -80,7 +81,7 @@ class GlazingOptionsMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class GlassPanesMixin(BaseOpenEpdHierarchicalSpec):
+class GlassPanesMixin(BaseOpenEpdSchema):
     """Glass panes mixin."""
 
     glass_panes: PositiveInt | None = pyd.Field(
@@ -90,7 +91,7 @@ class GlassPanesMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class DPRatingMixin(BaseOpenEpdHierarchicalSpec):
+class DPRatingMixin(BaseOpenEpdSchema):
     """Differential pressure rating mixin."""
 
     dp_rating: PressureMPaStr | None = pyd.Field(
@@ -98,7 +99,7 @@ class DPRatingMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class AirInfiltrationMixin(BaseOpenEpdHierarchicalSpec):
+class AirInfiltrationMixin(BaseOpenEpdSchema):
     """Air infiltration mixin."""
 
     air_infiltration: QuantityStr | None = pyd.Field(
@@ -108,7 +109,7 @@ class AirInfiltrationMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class AssemblyUFactorMixin(BaseOpenEpdHierarchicalSpec):
+class AssemblyUFactorMixin(BaseOpenEpdSchema):
     """Assembly U factor mixin."""
 
     assembly_u_factor: HeatConductanceUCIStr | None = pyd.Field(
@@ -118,7 +119,7 @@ class AssemblyUFactorMixin(BaseOpenEpdHierarchicalSpec):
     )
 
 
-class GlassIntendedApplicationMixin(BaseOpenEpdHierarchicalSpec):
+class GlassIntendedApplicationMixin(BaseOpenEpdSchema):
     """Glass intended application mixin."""
 
     glazing_intended_application_curtain_wall: bool | None = pyd.Field(
@@ -165,13 +166,13 @@ class ThermalSeparationEnum(StrEnum):
     NON_METAL = "Nonmetal"
 
 
-class ThermalSeparationMixin(BaseOpenEpdHierarchicalSpec):
+class ThermalSeparationMixin(BaseOpenEpdSchema):
     """Thermal separation mixin."""
 
     thermal_separation: ThermalSeparationEnum | None = pyd.Field(default=None, description="Thermal separation.")
 
 
-class HurricaneResistantMixin(BaseOpenEpdHierarchicalSpec):
+class HurricaneResistantMixin(BaseOpenEpdSchema):
     """Hurricane resistant mixin."""
 
     hurricane_resistant: bool | None = pyd.Field(

--- a/src/openepd/model/specs/steel.py
+++ b/src/openepd/model/specs/steel.py
@@ -50,11 +50,15 @@ class SteelComposition(StrEnum):
 class FabricatedOptionsMixin(pyd.BaseModel):
     """Fabricated options mixin."""
 
+    _EXT_VERSION = "1.0"
+
     fabricated: bool | None = pyd.Field(default=None, description="Fabricated")
 
 
 class WireMeshSteelV1(BaseOpenEpdHierarchicalSpec):
     """Spec for wire mesh steel."""
+
+    _EXT_VERSION = "1.0"
 
     class Options(BaseOpenEpdSchema, FabricatedOptionsMixin):
         """Wire Mesh Options."""
@@ -115,6 +119,8 @@ class RebarSteelV1(BaseOpenEpdHierarchicalSpec):
 class PlateSteelV1(BaseOpenEpdHierarchicalSpec):
     """Plate Steel Spec."""
 
+    _EXT_VERSION = "1.0"
+
     class Options(BaseOpenEpdSchema, FabricatedOptionsMixin):
         """Plate Steel Options."""
 
@@ -126,6 +132,8 @@ class PlateSteelV1(BaseOpenEpdHierarchicalSpec):
 class HollowV1(BaseOpenEpdHierarchicalSpec):
     """Hollow Sections Spec."""
 
+    _EXT_VERSION = "1.0"
+
     class Options(FabricatedOptionsMixin, BaseOpenEpdSchema):
         """Hollow Sections Options."""
 
@@ -136,6 +144,8 @@ class HollowV1(BaseOpenEpdHierarchicalSpec):
 
 class HotRolledV1(BaseOpenEpdHierarchicalSpec):
     """Hot Rolled spec."""
+
+    _EXT_VERSION = "1.0"
 
     class Options(FabricatedOptionsMixin, BaseOpenEpdSchema):
         """Hot Rolled options."""

--- a/src/openepd/model/tests/test_spec_completeness.py
+++ b/src/openepd/model/tests/test_spec_completeness.py
@@ -1,0 +1,53 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  This software was developed with support from the Skanska USA,
+#  Charles Pankow Foundation, Microsoft Sustainability Fund, Interface, MKA Foundation, and others.
+#  Find out more at www.BuildingTransparency.org
+#
+import importlib
+import inspect
+import pkgutil
+from typing import Iterable
+import unittest
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class SpecVersionTestCase(unittest.TestCase):
+    def test_ext_version_defined_for_all_specs(self):
+
+        modules = list(self.__find_iteratively("..specs", relative_to=__package__))
+        for name, module in modules:
+            material_specs_in_module = [
+                cls
+                for _, cls in inspect.getmembers(module, inspect.isclass)
+                if issubclass(cls, BaseOpenEpdHierarchicalSpec)
+                and cls.__module__ == module.__name__
+                and cls != BaseOpenEpdHierarchicalSpec
+            ]
+            for spec in material_specs_in_module:
+                self.assertIsNotNone(spec._EXT_VERSION, f"_EXT_VERSION is not defined for {spec.__name__}")
+
+    @classmethod
+    def __find_iteratively(cls, module_name: str, relative_to: str) -> Iterable[tuple[str, str]]:
+        spec = importlib.util.find_spec(module_name, relative_to)
+        if spec:
+            module = importlib.import_module(spec.name)
+            for module_info in pkgutil.walk_packages(module.__path__):
+                if module_info.ispkg:
+                    yield from cls.__find_iteratively(".".join((module.__name__, module_info.name)), relative_to)
+                else:
+                    yield module_info.name, importlib.import_module(".".join((module.__name__, module_info.name)))

--- a/src/openepd/model/validation/quantity.py
+++ b/src/openepd/model/validation/quantity.py
@@ -69,7 +69,9 @@ def validate_unit_factory(dimensionality: OpenEPDUnit | str):
 # for abitrary non-standard quantity
 QuantityStr: TypeAlias = Annotated[str, pyd.Field()]
 PressureMPaStr: TypeAlias = Annotated[str, pyd.Field(example="30 MPa")]
+MassKgStr: TypeAlias = Annotated[str, pyd.Field(example="30 kg")]
 LengthMmStr: TypeAlias = Annotated[str, pyd.Field(example="30 mm")]
+AreaM2Str: TypeAlias = Annotated[str, pyd.Field(example="12 m2")]
 LengthMStr: TypeAlias = Annotated[str, pyd.Field(example="30 m")]
 TemperatureCStr: TypeAlias = Annotated[str, pyd.Field(example="45 C")]
 HeatConductanceUCIStr: TypeAlias = Annotated[str, pyd.Field(example="0.3 U")]


### PR DESCRIPTION
fix: add default _EXT_VERSION to where it was missing

asana:[openEPD: Error class 'openepd.model.specs.steel.WireMeshSteelV1'> must declare an extension version when creating EPD with a sub-category except Rebar](https://app.asana.com/0/698742722983597/1206806670697104/f)