### PR TITLE
fix: correct examples for Org.subsidiaries for openapi

### DIFF
--- a/src/openepd/model/org.py
+++ b/src/openepd/model/org.py
@@ -53,7 +53,6 @@ class Org(WithAttachmentsMixin, WithAltIdsMixin, OrgRef):
     owner: Optional["Org"] = pyd.Field(description="Organization that controls this organization", default=None)
     subsidiaries: Annotated[list[str], pyd.conlist(pyd.constr(max_length=200), max_items=255)] | None = pyd.Field(
         description="Organizations controlled by this organization",
-        example=["cqd.io", "supplychaincarbonpricing.org"],
         default=None,
     )
     hq_location: Location | None = pyd.Field(


### PR DESCRIPTION
Now this is a composite field (entity), so no need for separate examples. 