### PR TITLE
fix: make naming in GE, IEPD api consistent with the rest of the API

### DIFF
--- a/src/openepd/api/average_dataset/generic_estimate_sync_api.py
+++ b/src/openepd/api/average_dataset/generic_estimate_sync_api.py
@@ -34,12 +34,12 @@ class GenericEstimateApi(BaseApiMethodGroup):
     """API methods for Generic Estimates."""
 
     @overload
-    def get_by_open_xpd_uuid(self, uuid: str, with_response: Literal[True]) -> tuple[GenericEstimate, Response]: ...
+    def get_by_openxpd_uuid(self, uuid: str, with_response: Literal[True]) -> tuple[GenericEstimate, Response]: ...
 
     @overload
-    def get_by_open_xpd_uuid(self, uuid: str, with_response: Literal[False] = False) -> GenericEstimate: ...
+    def get_by_openxpd_uuid(self, uuid: str, with_response: Literal[False] = False) -> GenericEstimate: ...
 
-    def get_by_open_xpd_uuid(
+    def get_by_openxpd_uuid(
         self, uuid: str, with_response: bool = False
     ) -> GenericEstimate | tuple[GenericEstimate, Response]:
         """

--- a/src/openepd/api/average_dataset/industry_epd_sync_api.py
+++ b/src/openepd/api/average_dataset/industry_epd_sync_api.py
@@ -29,14 +29,12 @@ class IndustryEpdApi(BaseApiMethodGroup):
     """API methods for Industry EPD."""
 
     @overload
-    def get_by_open_xpd_uuid(self, uuid: str, with_response: Literal[True]) -> tuple[IndustryEpd, Response]: ...
+    def get_by_openxpd_uuid(self, uuid: str, with_response: Literal[True]) -> tuple[IndustryEpd, Response]: ...
 
     @overload
-    def get_by_open_xpd_uuid(self, uuid: str, with_response: Literal[False] = False) -> IndustryEpd: ...
+    def get_by_openxpd_uuid(self, uuid: str, with_response: Literal[False] = False) -> IndustryEpd: ...
 
-    def get_by_open_xpd_uuid(
-        self, uuid: str, with_response: bool = False
-    ) -> IndustryEpd | tuple[IndustryEpd, Response]:
+    def get_by_openxpd_uuid(self, uuid: str, with_response: bool = False) -> IndustryEpd | tuple[IndustryEpd, Response]:
         """
         Get Industry EPD by OpenEPD UUID.
 

--- a/src/openepd/api/test/test_sync_api_client.py
+++ b/src/openepd/api/test/test_sync_api_client.py
@@ -126,7 +126,7 @@ class SyncClientApiTestCase(unittest.TestCase):
         self.assertEqual(3, len(list(first_three)))
 
     def test_get_generic_estimate_by_id(self):
-        ge, resp = self.api_client.generic_estimates.get_by_open_xpd_uuid("EC34BT54", with_response=True)
+        ge, resp = self.api_client.generic_estimates.get_by_openxpd_uuid("EC34BT54", with_response=True)
         self.assertEqual(ge.id, "EC34BT54")
         self.assertEqual(resp.status_code, 200)
 
@@ -138,7 +138,7 @@ class SyncClientApiTestCase(unittest.TestCase):
             self.assertIsInstance(e, IndustryEpdPreview)
 
     def test_get_industry_epd_by_id(self):
-        ge, resp = self.api_client.industry_epds.get_by_open_xpd_uuid("EC3GGJEJ", with_response=True)
+        ge, resp = self.api_client.industry_epds.get_by_openxpd_uuid("EC3GGJEJ", with_response=True)
         self.assertEqual(ge.id, "EC3GGJEJ")
         self.assertEqual(resp.status_code, 200)
 


### PR DESCRIPTION
fix: make naming in GE, IEPD api consistent with the rest of the API