### PR TITLE
fix: fix root validator for Amount

### DIFF
--- a/src/openepd/model/common.py
+++ b/src/openepd/model/common.py
@@ -29,7 +29,7 @@ class Amount(BaseOpenEpdSchema):
     @pyd.root_validator
     def check_qty_or_unit(cls, values: dict[str, Any]):
         """Ensure that qty or unit is provided."""
-        if values["qty"] is None and values["unit"] is None:
+        if values.get("qty") is None and values.get("unit") is None:
             raise ValueError("Either qty or unit must be provided.")
         return values
 


### PR DESCRIPTION
As root validators are invoked even if some fields are errored, we can not rely on them present in the `values` dict always.

asana: [[OpenEPD] 500 error on attempt to create new Industry EPD and Generic Estimates](https://app.asana.com/0/1203527467850668/1207905204242938/f)