### PR TITLE
Add a generator + Range specs for IEPD, GE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,11 +213,14 @@ print-version:
 		cz version --project; \
 	)
 
-codegen:
+codegen-internal:
 	@( \
        if [ -z $(SKIP_VENV) ]; then source $(VIRTUAL_ENV_PATH)/bin/activate; fi; \
        echo "Generating code..."; \
        python ./tools/openepd/codegen/generate_geography_enum.py > ./src/openepd/model/geography.py; \
+       PYTHONPATH=$PYTHONPATH:./src python ./tools/openepd/codegen/generate_range_spec_models.py openepd.model.specs.generated ./src/openepd/model/specs/range; \
        \
        echo "DONE: Generating code"; \
     )
+
+codegen: codegen-internal isort copyright format

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ codes, UN m49 codification, and special regions. To update the enums, first upda
 Windows is not supported for development. You can use WSL2 with Ubuntu 20.04 or higher.
 Instructions are the same as for regular GNU/Linux installation.
 
+### Commit messages
+
+Commit messages should follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#specification) 
+specification as we use automatic version with [commitizen](https://commitizen-tools.github.io/commitizen/).
+
 # Credits
 
 This library has been written and maintained by [C-Change Labs](https://c-change-labs.com/).

--- a/poetry.lock
+++ b/poetry.lock
@@ -508,13 +508,13 @@ colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.4"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
-    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
 ]
 
 [package.dependencies]
@@ -1021,6 +1021,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1385,4 +1386,4 @@ api-client = ["requests"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b5b5fd3da303c974e8c06364c26c4f59471f6beccb6c52d5533c84877d8ae2a7"
+content-hash = "1f6b3b79253f4d8cfb52cbc280679ea100f03b05659d593bb6cc739c07194095"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pytest-subtests = "~=0.4"
 pytest-cov = "~=4.0"
 teamcity-messages = ">=1.31"
 wheel = "~=0.40.0"
+click = "~=8.1.7"
 
 # Dev tools
 black = "~=24.3"
@@ -58,7 +59,7 @@ types-requests = ">=2.0"
 # Code generation
 # For list of countries
 pycountry = ">=24.6.1"
-jinja2 = ">=2.10.3"
+jinja2 = ">=3.1.4"
 
 
 [tool.poetry.extras]

--- a/src/openepd/model/common.py
+++ b/src/openepd/model/common.py
@@ -167,25 +167,25 @@ class RangeBase(BaseOpenEpdSchema):
 class RangeFloat(RangeBase):
     """Structure representing a range of floats."""
 
-    min: float | None = pyd.Field(default=None, example="3.1")
-    max: float | None = pyd.Field(default=None, example="5.8")
+    min: float | None = pyd.Field(default=None, example=3.1)
+    max: float | None = pyd.Field(default=None, example=5.8)
 
 
 class RangeInt(RangeBase):
     """Structure representing a range of ints1."""
 
-    min: int | None = pyd.Field(default=None, example="2")
-    max: int | None = pyd.Field(default=None, example="3")
+    min: int | None = pyd.Field(default=None, example=2)
+    max: int | None = pyd.Field(default=None, example=3)
 
 
 class RangeRatioFloat(RangeFloat):
     """Range of ratios (0-1 to 0-10)."""
 
-    min: float | None = pyd.Field(default=None, example="0.2", ge=0, le=1)
-    max: float | None = pyd.Field(default=None, example="0.65", ge=0, le=1)
+    min: float | None = pyd.Field(default=None, example=0.2, ge=0, le=1)
+    max: float | None = pyd.Field(default=None, example=0.65, ge=0, le=1)
 
 
 class RangeAmount(RangeFloat):
     """Structure representing a range of quantities."""
 
-    unit: str | None = pyd.Field(default=None, description="Unit of the range.", example="kg")
+    unit: str | None = pyd.Field(default=None, description="Unit of the range.")

--- a/src/openepd/model/common.py
+++ b/src/openepd/model/common.py
@@ -150,3 +150,42 @@ class OpenEPDUnit(StrEnum):
     degree_c = "°C"
     kg_co2 = "kgCO2e"
     hour = "hour"
+
+
+class RangeBase(BaseOpenEpdSchema):
+    """Base class for range types having min and max and order between them."""
+
+    @pyd.root_validator
+    def _validate_range_bounds(cls, values: dict[str, Any]) -> dict[str, Any]:
+        min_boundary = values.get("min")
+        max_boundary = values.get("max")
+        if min_boundary is not None and max_boundary is not None and min_boundary > max_boundary:
+            raise ValueError("Max should be greater than min")
+        return values
+
+
+class RangeFloat(RangeBase):
+    """Structure representing a range of floats."""
+
+    min: float | None = pyd.Field(default=None, example="3.1")
+    max: float | None = pyd.Field(default=None, example="5.8")
+
+
+class RangeInt(RangeBase):
+    """Structure representing a range of ints1."""
+
+    min: int | None = pyd.Field(default=None, example="2")
+    max: int | None = pyd.Field(default=None, example="3")
+
+
+class RangeRatioFloat(RangeFloat):
+    """Range of ratios (0-1 to 0-10)."""
+
+    min: float | None = pyd.Field(default=None, example="0.2", ge=0, le=1)
+    max: float | None = pyd.Field(default=None, example="0.65", ge=0, le=1)
+
+
+class RangeAmount(RangeFloat):
+    """Structure representing a range of quantities."""
+
+    unit: str | None = pyd.Field(default=None, description="Unit of the range.", example="kg")

--- a/src/openepd/model/declaration.py
+++ b/src/openepd/model/declaration.py
@@ -22,6 +22,7 @@ from openepd.model.common import Amount
 from openepd.model.geography import Geography
 from openepd.model.org import Org
 from openepd.model.pcr import Pcr
+from openepd.model.specs.range import SpecsRange
 from openepd.model.standard import Standard
 from openepd.model.validation.common import ReferenceStr
 from openepd.model.validation.quantity import AmountGWP, AmountMass
@@ -172,6 +173,8 @@ class AverageDatasetMixin(pyd.BaseModel, title="Average Dataset"):
         description="Jurisdiction(s) in which the LCA result is applicable.  An empty array, or absent properties, "
         "implies global applicability.",
     )
+
+    specs: SpecsRange | None = pyd.Field(default=None, description="Average dataset material performance specifiction.")
 
 
 class WithProgramOperatorMixin(pyd.BaseModel):

--- a/src/openepd/model/declaration.py
+++ b/src/openepd/model/declaration.py
@@ -142,14 +142,14 @@ class BaseDeclaration(RootDocument, abc.ABC):
         description="Mass of elemental carbon, per declared unit, contained in the product itself at the manufacturing "
         "facility gate.  Used (among other things) to check a carbon balance or calculate incineration "
         "emissions.  The source of carbon (e.g. biogenic) is not relevant in this field.",
-        example=Amount(qty=8.76, unit="kgCO2e"),
+        example=Amount(qty=8.76, unit="kgCO2e").to_serializable(exclude_unset=True),
     )
     kg_C_biogenic_per_declared_unit: AmountGWP | None = pyd.Field(
         default=None,
         description="Mass of elemental carbon from biogenic sources, per declared unit, contained in the product "
         "itself at the manufacturing facility gate.  It may be presumed that any biogenic carbon content "
         "has been accounted for as -44/12 kgCO2e per kg C in stages A1-A3, per EN15804 and ISO 21930.",
-        example=Amount(qty=8.76, unit="kgCO2e"),
+        example=Amount(qty=8.76, unit="kgCO2e").to_serializable(exclude_unset=True),
     )
     product_service_life_years: float | None = pyd.Field(
         gt=0.0009,
@@ -174,7 +174,9 @@ class AverageDatasetMixin(pyd.BaseModel, title="Average Dataset"):
         "implies global applicability.",
     )
 
-    specs: SpecsRange | None = pyd.Field(default=None, description="Average dataset material performance specifiction.")
+    specs: SpecsRange | None = pyd.Field(
+        default=None, description="Average dataset material performance specifications."
+    )
 
 
 class WithProgramOperatorMixin(pyd.BaseModel):

--- a/src/openepd/model/geography.py
+++ b/src/openepd/model/geography.py
@@ -279,7 +279,7 @@ class Geography(StrEnum):
      * ZM: Zambia
      * ZW: Zimbabwe
 
-    USA and Canada subdivisions, see https://en.wikipedia.org/wiki/ISO_3166-1:
+    USA states and Canada provinces, see https://en.wikipedia.org/wiki/ISO_3166-1:
 
      * CA-AB: Alberta, Canada
      * CA-BC: British Columbia, Canada

--- a/src/openepd/model/lcia.py
+++ b/src/openepd/model/lcia.py
@@ -681,12 +681,15 @@ class WithLciaMixin(BaseOpenEpdSchema):
     """Mixin for LCIA data."""
 
     impacts: Impacts | None = pyd.Field(
-        description="List of environmental impacts, compiled per one of the standard Impact Assessment methods"
+        description="List of environmental impacts, compiled per one of the standard Impact Assessment methods",
+        example={"TRACI 2.1": {"gwp": {"A1A2A3": {"mean": 22.4, "unit": "kgCO2e"}}}},
     )
     resource_uses: ResourceUseSet | None = pyd.Field(
-        description="Set of Resource Use Indicators, over various LCA scopes"
+        description="Set of Resource Use Indicators, over various LCA scopes",
+        example={"RPRe": {"A1A2A3": {"mean": 12, "unit": "MJ", "rsd": 0.12}}},
     )
     output_flows: OutputFlowSet | None = pyd.Field(
         description="Set of Waste and Output Flow indicators which describe the waste categories "
-        "and other material output flows derived from the LCI."
+        "and other material output flows derived from the LCI.",
+        example={"hwd": {"A1A2A3": {"mean": 2300, "unit": "kg", "rsd": 0.22}}},
     )

--- a/src/openepd/model/pcr.py
+++ b/src/openepd/model/pcr.py
@@ -91,12 +91,12 @@ class Pcr(WithAttachmentsMixin, WithAltIdsMixin, BaseOpenEpdSchema):
         default=None,
     )
     date_of_issue: datetime.datetime | None = pyd.Field(
-        example=datetime.date(day=11, month=2, year=2022),
+        example=datetime.datetime(day=11, month=9, year=2019, tzinfo=datetime.timezone.utc),
         default=None,
         description="First day on which the document is valid",
     )
     valid_until: datetime.datetime | None = pyd.Field(
-        example=datetime.date(day=11, month=2, year=2024),
+        example=datetime.datetime(day=11, month=9, year=2019, tzinfo=datetime.timezone.utc),
         default=None,
         description="Last day on which the document is valid",
     )

--- a/src/openepd/model/specs/README.md
+++ b/src/openepd/model/specs/README.md
@@ -1,19 +1,45 @@
 # Material Extensions
 
-This package contains openEPD material extensions. They are used to represent the material properties of the openEPD 
-materials, and are a more dynamic, frequently changing part of the standard. 
+This package contains openEPD material extensions. They are used to represent the material properties of the openEPD
+materials, and are a more dynamic, frequently changing part of the standard.
 
 ## Versioning
 
-Extensions are versioned separately from the openEPD standard or openEPD API. 
+Extensions are versioned separately from the openEPD standard or openEPD API.
 
-Each material extension is named after the corresponding EC3 product class, and is located in the relevant place 
-in the specs tree. For example, `RebarSteel` is nested under `Steel`. 
+Each material extension is named after the corresponding EC3 product class, and is located in the relevant place
+in the specs tree. For example, `RebarSteel` is nested under `Steel`.
 
-Extensions are versioned as Major.Minor, for example "2.4". 
+Extensions are versioned as Major.Minor, for example "2.4".
 
-Rules: 
+Rules:
+
 1. Minor versions for the same major version should be backwards compatible.
-2. Major versions are not compatible between themselves. 
+2. Major versions are not compatible between themselves.
 3. Pydantic models representing versions are named in a pattern SpecNameV1, where 1 is major version and SpecName is
    the name of the material extension.
+
+## Range specs
+
+Normal EPDs get singular specs (e.g. `SteelV1`). Single specs can express performance parameters of one concrete
+material/EPD. However, the IndustryEDPs and Generic Estimates often cover a specific segment of the market, and
+include a range of products under the hood, thus demanding for ranges. For example, a single EPD has one `strength_28d`
+of `4000 psi`, but an industry EPD can be applicable to certain concretes in the range of `4000 psi` to `5000 psi`.
+
+Range specs are used to express that. Range specs are located in `specs.range` package, and are auto-generated from the
+single specs, please see `make codegen` command and `tools/openepd/codegen/generate_range_spec_models.py`
+
+Range specs are created by following general rules:
+
+1. A QuantityStr (such as `QuantityMassKg`) becomes an `AmountRange` of certain type - `AmountRangeMass`
+2. Float -> RangeFloat, Ratio -> RatioRange, int -> IntRange
+3. Enums become lists of enums, for example: `cable_trays_material: enums.CableTrayMaterial` in normal spec becomes a
+   `cable_trays_material: list[enums.CabeTrayMaterial]` in the range spec.
+4. Complex objects, strings remain unchanged.
+
+This is, however, not always desired. For example, `recarbonation: float` and `recarbonation_z: float` property of CMU
+should not be converted to ranges as these do not make sense.
+
+The default rule-base behaviour can be overridden with the
+`CodeGenSpec` class annotation like this: `recarbonation: Annotated[float, CodeGenSpec(override_type=float)]` in single
+spec to make RangeSpec have normal `float` type.

--- a/src/openepd/model/specs/asphalt.py
+++ b/src/openepd/model/specs/asphalt.py
@@ -19,7 +19,7 @@ from openepd.compat.pydantic import pyd
 from openepd.model.common import OpenEPDUnit
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
 from openepd.model.validation.numbers import RatioFloat
-from openepd.model.validation.quantity import LengthMmStr, TemperatureCStr, validate_unit_factory
+from openepd.model.validation.quantity import LengthMmStr, TemperatureCStr, validate_quantity_unit_factory
 
 
 class AsphaltMixType(StrEnum):
@@ -79,5 +79,5 @@ class AsphaltV1(BaseOpenEpdHierarchicalSpec):
     asphalt_pmb: bool | None = pyd.Field(default=None, description="Polymer modified bitumen (PMB)")
 
     _aggregate_size_max_validator = pyd.validator("asphalt_aggregate_size_max", allow_reuse=True)(
-        validate_unit_factory(OpenEPDUnit.m)
+        validate_quantity_unit_factory(OpenEPDUnit.m)
     )

--- a/src/openepd/model/specs/base.py
+++ b/src/openepd/model/specs/base.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import dataclasses
 from typing import Any
 
 from openepd.compat.pydantic import pyd
@@ -51,3 +52,15 @@ class BaseOpenEpdHierarchicalSpec(BaseOpenEpdSpec, WithExtVersionMixin):
 def setup_external_validators(quantity_validator: QuantityValidator):
     """Set the implementation unit validator for specs."""
     ExternalValidationConfig.QUANTITY_VALIDATOR = quantity_validator
+
+
+@dataclasses.dataclass(kw_only=True)
+class CodegenSpec:
+    """
+    Specification for codegen when generating RangeSpecs from normal specs.
+
+    See openepd.mode.specs.README.md for details.
+    """
+
+    exclude_from_codegen: bool = False
+    override_type: type

--- a/src/openepd/model/specs/generated/__init__.py
+++ b/src/openepd/model/specs/generated/__init__.py
@@ -13,3 +13,83 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.accessories import AccessoriesV1
+from openepd.model.specs.generated.aggregates import AggregatesV1
+from openepd.model.specs.generated.aluminium import AluminiumV1
+from openepd.model.specs.generated.asphalt import AsphaltV1
+from openepd.model.specs.generated.bulk_materials import BulkMaterialsV1
+from openepd.model.specs.generated.cast_decks_and_underlayment import CastDecksAndUnderlaymentV1
+from openepd.model.specs.generated.cladding import CladdingV1
+from openepd.model.specs.generated.cmu import CMUV1
+from openepd.model.specs.generated.concrete import ConcreteV1
+from openepd.model.specs.generated.conveying_equipment import ConveyingEquipmentV1
+from openepd.model.specs.generated.electrical import ElectricalV1
+from openepd.model.specs.generated.electrical_transmission_and_distribution_equipment import (
+    ElectricalTransmissionAndDistributionEquipmentV1,
+)
+from openepd.model.specs.generated.electricity import ElectricityV1
+from openepd.model.specs.generated.finishes import FinishesV1
+from openepd.model.specs.generated.fire_and_smoke_protection import FireAndSmokeProtectionV1
+from openepd.model.specs.generated.furnishings import FurnishingsV1
+from openepd.model.specs.generated.grouting import GroutingV1
+from openepd.model.specs.generated.manufacturing_inputs import ManufacturingInputsV1
+from openepd.model.specs.generated.masonry import MasonryV1
+from openepd.model.specs.generated.material_handling import MaterialHandlingV1
+from openepd.model.specs.generated.mechanical import MechanicalV1
+from openepd.model.specs.generated.mechanical_insulation import MechanicalInsulationV1
+from openepd.model.specs.generated.network_infrastructure import NetworkInfrastructureV1
+from openepd.model.specs.generated.openings import OpeningsV1
+from openepd.model.specs.generated.other_electrical_equipment import OtherElectricalEquipmentV1
+from openepd.model.specs.generated.other_materials import OtherMaterialsV1
+from openepd.model.specs.generated.plumbing import PlumbingV1
+from openepd.model.specs.generated.precast_concrete import PrecastConcreteV1
+from openepd.model.specs.generated.sheathing import SheathingV1
+from openepd.model.specs.generated.steel import SteelV1
+from openepd.model.specs.generated.thermal_moisture_protection import ThermalMoistureProtectionV1
+from openepd.model.specs.generated.utility_piping import UtilityPipingV1
+from openepd.model.specs.generated.wood import WoodV1
+from openepd.model.specs.generated.wood_joists import WoodJoistsV1
+
+
+class Specs(BaseOpenEpdHierarchicalSpec):
+    """Material specific specs."""
+
+    _EXT_VERSION = "1.0"
+
+    # Nested specs:
+    CMU: CMUV1 | None = None
+    Masonry: MasonryV1 | None = None
+    Steel: SteelV1 | None = None
+    NetworkInfrastructure: NetworkInfrastructureV1 | None = None
+    Finishes: FinishesV1 | None = None
+    ManufacturingInputs: ManufacturingInputsV1 | None = None
+    Accessories: AccessoriesV1 | None = None
+    ElectricalTransmissionAndDistributionEquipment: ElectricalTransmissionAndDistributionEquipmentV1 | None = None
+    Aggregates: AggregatesV1 | None = None
+    ThermalMoistureProtection: ThermalMoistureProtectionV1 | None = None
+    Mechanical: MechanicalV1 | None = None
+    Aluminium: AluminiumV1 | None = None
+    Cladding: CladdingV1 | None = None
+    FireAndSmokeProtection: FireAndSmokeProtectionV1 | None = None
+    PrecastConcrete: PrecastConcreteV1 | None = None
+    Asphalt: AsphaltV1 | None = None
+    OtherMaterials: OtherMaterialsV1 | None = None
+    Plumbing: PlumbingV1 | None = None
+    Electrical: ElectricalV1 | None = None
+    UtilityPiping: UtilityPipingV1 | None = None
+    BulkMaterials: BulkMaterialsV1 | None = None
+    CastDecksAndUnderlayment: CastDecksAndUnderlaymentV1 | None = None
+    Concrete: ConcreteV1 | None = None
+    Sheathing: SheathingV1 | None = None
+    Furnishings: FurnishingsV1 | None = None
+    Wood: WoodV1 | None = None
+    ConveyingEquipment: ConveyingEquipmentV1 | None = None
+    MaterialHandling: MaterialHandlingV1 | None = None
+    Openings: OpeningsV1 | None = None
+    Electricity: ElectricityV1 | None = None
+    Grouting: GroutingV1 | None = None
+    MechanicalInsulation: MechanicalInsulationV1 | None = None
+    OtherElectricalEquipment: OtherElectricalEquipmentV1 | None = None
+    WoodJoists: WoodJoistsV1 | None = None

--- a/src/openepd/model/specs/generated/cladding.py
+++ b/src/openepd/model/specs/generated/cladding.py
@@ -16,7 +16,7 @@
 from openepd.compat.pydantic import pyd
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
 from openepd.model.specs.generated.enums import CladdingFacingMaterial, CladdingInsulatingMaterial, SidingFormFactor
-from openepd.model.validation.quantity import LengthMmStr, LengthMStr, RValueStr, validate_unit_factory
+from openepd.model.validation.quantity import LengthMmStr, LengthMStr, RValueStr, validate_quantity_unit_factory
 
 
 class AluminiumSidingV1(BaseOpenEpdHierarchicalSpec):
@@ -75,7 +75,7 @@ class InsulatedVinylSidingV1(BaseOpenEpdHierarchicalSpec):
     thickness: LengthMmStr | None = pyd.Field(default=None, description="", example="1 mm")
 
     _vinyl_siding_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(
-        validate_unit_factory("m")
+        validate_quantity_unit_factory("m")
     )
 
 
@@ -109,7 +109,7 @@ class VinylSidingV1(BaseOpenEpdHierarchicalSpec):
     thickness: LengthMmStr | None = pyd.Field(default=None, description="", example="5 mm")
 
     _vinyl_siding_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(
-        validate_unit_factory("m")
+        validate_quantity_unit_factory("m")
     )
 
 
@@ -191,7 +191,7 @@ class CladdingV1(BaseOpenEpdHierarchicalSpec):
     thickness: LengthMStr | None = pyd.Field(default=None, description="", example="10 mm")
     facing_material: CladdingFacingMaterial | None = pyd.Field(default=None, description="", example="Steel")
 
-    _thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(validate_unit_factory("m"))
+    _thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(validate_quantity_unit_factory("m"))
 
     # Nested specs:
     Siding: SidingV1 | None = None

--- a/src/openepd/model/specs/generated/concrete.py
+++ b/src/openepd/model/specs/generated/concrete.py
@@ -13,10 +13,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from typing import Literal
+from typing import Annotated, Literal
 
 from openepd.compat.pydantic import pyd
-from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec, CodegenSpec
 from openepd.model.specs.concrete import Cementitious, ConcreteTypicalApplication
 from openepd.model.specs.generated.enums import AciExposureClass, CsaExposureClass, EnExposureClass
 from openepd.model.validation.numbers import RatioFloat
@@ -25,7 +25,7 @@ from openepd.model.validation.quantity import (
     LengthMmStr,
     MassKgStr,
     PressureMPaStr,
-    validate_unit_factory,
+    validate_quantity_unit_factory,
 )
 
 
@@ -53,7 +53,7 @@ class ConcretePavingV1(BaseOpenEpdHierarchicalSpec):
     )
 
     _concrete_flexion_strength_is_quantity_validator = pyd.validator("flexion_strength", allow_reuse=True)(
-        validate_unit_factory("MPa")
+        validate_quantity_unit_factory("MPa")
     )
 
 
@@ -119,9 +119,10 @@ class ConcreteV1(BaseOpenEpdHierarchicalSpec):
         description="A strength spec which is to be reached later other 28 days (e.g. 42d)",
         example="30 MPa",
     )
-    strength_other_d: Literal[3, 7, 14, 42, 56, 72, 96, 120] | None = pyd.Field(
-        default=None, description="Test Day for strength_other", example=42
-    )
+    strength_other_d: Annotated[
+        Literal[3, 7, 14, 42, 56, 72, 96, 120] | None,
+        CodegenSpec(override_type=Literal[3, 7, 14, 42, 56, 72, 96, 120]),
+    ] = pyd.Field(default=None, description="Test Day for strength_other", example=42)
 
     slump: LengthInchStr | None = pyd.Field(default=None, description="", example="2 in")
     min_slump: LengthInchStr | None = pyd.Field(default=None, description="Minimum test slump", example="2 in")

--- a/src/openepd/model/specs/generated/electrical.py
+++ b/src/openepd/model/specs/generated/electrical.py
@@ -26,7 +26,7 @@ from openepd.model.validation.quantity import (
     PowerStr,
     validate_quantity_ge_factory,
     validate_quantity_le_factory,
-    validate_unit_factory,
+    validate_quantity_unit_factory,
 )
 
 
@@ -268,7 +268,7 @@ class LightingV1(BaseOpenEpdHierarchicalSpec):
         validate_quantity_le_factory("1E+04 K")
     )
     _typical_utilization_unit_validator = pyd.validator("typical_utilization", allow_reuse=True)(
-        validate_unit_factory("h / yr")
+        validate_quantity_unit_factory("h / yr")
     )
     _typical_utilization_quantity_ge_validator = pyd.validator("typical_utilization", allow_reuse=True)(
         validate_quantity_ge_factory("25 h / yr")

--- a/src/openepd/model/specs/generated/finishes.py
+++ b/src/openepd/model/specs/generated/finishes.py
@@ -52,7 +52,7 @@ from openepd.model.validation.quantity import (
     PressureMPaStr,
     validate_quantity_ge_factory,
     validate_quantity_le_factory,
-    validate_unit_factory,
+    validate_quantity_unit_factory,
 )
 
 
@@ -85,10 +85,10 @@ class AccessFlooringV1(BaseOpenEpdHierarchicalSpec):
 
     _access_flooring_rolling_load_10_pass_is_quantity_validator = pyd.validator(
         "rolling_load_10_pass", allow_reuse=True
-    )(validate_unit_factory("N"))
+    )(validate_quantity_unit_factory("N"))
     _access_flooring_rolling_load_10000_pass_is_quantity_validator = pyd.validator(
         "rolling_load_10000_pass", allow_reuse=True
-    )(validate_unit_factory("N"))
+    )(validate_quantity_unit_factory("N"))
 
 
 class CarpetV1(BaseOpenEpdHierarchicalSpec):
@@ -114,7 +114,9 @@ class CarpetV1(BaseOpenEpdHierarchicalSpec):
     gwp_factor_base: GwpKgCo2eStr | None = pyd.Field(default=None, description="", example="1 kgCO2e")
     gwp_factor_yarn: GwpKgCo2eStr | None = pyd.Field(default=None, description="", example="1 kgCO2e")
 
-    _yarn_weight_is_quantity_validator = pyd.validator("yarn_weight", allow_reuse=True)(validate_unit_factory("g / m2"))
+    _yarn_weight_is_quantity_validator = pyd.validator("yarn_weight", allow_reuse=True)(
+        validate_quantity_unit_factory("g / m2")
+    )
     _yarn_weight_ge_validator = pyd.validator("yarn_weight", allow_reuse=True)(validate_quantity_ge_factory("0 g / m2"))
 
 
@@ -348,7 +350,7 @@ class CementBoardV1(BaseOpenEpdHierarchicalSpec):
     )
 
     _cement_board_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(
-        validate_unit_factory("m")
+        validate_quantity_unit_factory("m")
     )
 
 
@@ -456,7 +458,9 @@ class GypsumV1(BaseOpenEpdHierarchicalSpec):
     moisture_resistant: bool | None = pyd.Field(default=None, description="", example=True)
     abuse_resistant: bool | None = pyd.Field(default=None, description="", example=True)
 
-    _gypsum_r_factor_is_quantity_validator = pyd.validator("r_factor", allow_reuse=True)(validate_unit_factory("RSI"))
+    _gypsum_r_factor_is_quantity_validator = pyd.validator("r_factor", allow_reuse=True)(
+        validate_quantity_unit_factory("RSI")
+    )
 
     # Nested specs:
     GypsumSupports: GypsumSupportsV1 | None = None

--- a/src/openepd/model/specs/generated/masonry.py
+++ b/src/openepd/model/specs/generated/masonry.py
@@ -15,7 +15,11 @@
 #
 from openepd.compat.pydantic import pyd
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
-from openepd.model.validation.quantity import PressureMPaStr, validate_quantity_ge_factory, validate_unit_factory
+from openepd.model.validation.quantity import (
+    PressureMPaStr,
+    validate_quantity_ge_factory,
+    validate_quantity_unit_factory,
+)
 
 
 class GMUV1(BaseOpenEpdHierarchicalSpec):
@@ -35,7 +39,7 @@ class AutoclavedAeratedConcreteV1(BaseOpenEpdHierarchicalSpec):
     white: bool | None = pyd.Field(default=None, description="", example=True)
 
     _aac_thermal_conductivity_is_quantity_validator = pyd.validator("thermal_conductivity", allow_reuse=True)(
-        validate_unit_factory("W / (m * K)")
+        validate_quantity_unit_factory("W / (m * K)")
     )
 
     _aac_thermal_conductivity_min_validator = pyd.validator("thermal_conductivity", allow_reuse=True)(

--- a/src/openepd/model/specs/generated/network_infrastructure.py
+++ b/src/openepd/model/specs/generated/network_infrastructure.py
@@ -28,7 +28,12 @@ from openepd.model.specs.generated.enums import (
     RackType,
 )
 from openepd.model.specs.generated.mixins.conduit_mixin import ConduitMixin
-from openepd.model.validation.quantity import ElectricalCurrentStr, LengthMmStr, MassKgStr, validate_unit_factory
+from openepd.model.validation.quantity import (
+    ElectricalCurrentStr,
+    LengthMmStr,
+    MassKgStr,
+    validate_quantity_unit_factory,
+)
 
 
 class PDUV1(BaseOpenEpdHierarchicalSpec):
@@ -43,7 +48,7 @@ class PDUV1(BaseOpenEpdHierarchicalSpec):
     pdu_technology: PduTechnology | None = pyd.Field(default=None, description="", example="Basic")
     pdu_outlets: int | None = pyd.Field(default=None, description="", example=3, le=200)
 
-    _amperage_is_quantity_validator = pyd.validator("amperage", allow_reuse=True)(validate_unit_factory("A"))
+    _amperage_is_quantity_validator = pyd.validator("amperage", allow_reuse=True)(validate_quantity_unit_factory("A"))
 
 
 class CabinetsRacksAndEnclosuresV1(BaseOpenEpdHierarchicalSpec):

--- a/src/openepd/model/specs/generated/openings.py
+++ b/src/openepd/model/specs/generated/openings.py
@@ -26,7 +26,7 @@ from openepd.model.specs.generated.enums import (
     ThermalSeparation,
 )
 from openepd.model.validation.numbers import RatioFloat
-from openepd.model.validation.quantity import LengthMmStr, PressureMPaStr, SpeedStr, validate_unit_factory
+from openepd.model.validation.quantity import LengthMmStr, PressureMPaStr, SpeedStr, validate_quantity_unit_factory
 
 
 class GlazingIntendedApplication(BaseOpenEpdSchema):
@@ -197,7 +197,7 @@ class FlatGlassPanesV1(BaseOpenEpdHierarchicalSpec):
     thickness: FlatGlassPanesThickness | None = pyd.Field(default=None, example="12 mm")
 
     _flat_glass_panes_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(
-        validate_unit_factory("m")
+        validate_quantity_unit_factory("m")
     )
 
 
@@ -380,10 +380,10 @@ class NAFSFenestrationV1(BaseOpenEpdHierarchicalSpec, GlazingOptionsMixin):
     )
 
     _assembly_u_factor_is_quantity_validator = pyd.validator("assembly_u_factor", allow_reuse=True)(
-        validate_unit_factory("USI")
+        validate_quantity_unit_factory("USI")
     )
     _nafs_performance_grade_is_quantity_validator = pyd.validator("performance_grade", allow_reuse=True)(
-        validate_unit_factory("psf")
+        validate_quantity_unit_factory("psf")
     )
 
     # Nested specs:
@@ -424,8 +424,12 @@ class InsulatingGlazingUnitsV1(BaseOpenEpdHierarchicalSpec, GlazingOptionsMixin)
         default=None, description="Spacer material for Integrated Glass Unit.", example="Aluminium"
     )
 
-    _dp_rating_is_quantity_validator = pyd.validator("dp_rating", allow_reuse=True)(validate_unit_factory("MPa"))
-    _cog_u_factor_is_quantity_validator = pyd.validator("cog_u_factor", allow_reuse=True)(validate_unit_factory("USI"))
+    _dp_rating_is_quantity_validator = pyd.validator("dp_rating", allow_reuse=True)(
+        validate_quantity_unit_factory("MPa")
+    )
+    _cog_u_factor_is_quantity_validator = pyd.validator("cog_u_factor", allow_reuse=True)(
+        validate_quantity_unit_factory("USI")
+    )
 
 
 class CurtainWallsV1(BaseOpenEpdHierarchicalSpec):

--- a/src/openepd/model/specs/generated/sheathing.py
+++ b/src/openepd/model/specs/generated/sheathing.py
@@ -16,7 +16,7 @@
 from openepd.compat.pydantic import pyd
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
 from openepd.model.specs.generated.enums import GypsumFacing, GypsumFireRating, GypsumThickness
-from openepd.model.validation.quantity import LengthMmStr, validate_unit_factory
+from openepd.model.validation.quantity import LengthMmStr, validate_quantity_unit_factory
 
 
 class CementitiousSheathingBoardV1(BaseOpenEpdHierarchicalSpec):
@@ -33,7 +33,7 @@ class CementitiousSheathingBoardV1(BaseOpenEpdHierarchicalSpec):
     cement_board_thickness: LengthMmStr | None = pyd.Field(default=None, description="", example="10 mm")
 
     _cement_board_thickness_is_quantity_validator = pyd.validator("cement_board_thickness", allow_reuse=True)(
-        validate_unit_factory("m")
+        validate_quantity_unit_factory("m")
     )
 
 
@@ -65,8 +65,12 @@ class GypsumSheathingBoardV1(BaseOpenEpdHierarchicalSpec):
     moisture_resistant: bool | None = pyd.Field(default=None, description="", example=True)
     abuse_resistant: bool | None = pyd.Field(default=None, description="", example=True)
 
-    _gypsum_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(validate_unit_factory("m"))
-    _gypsum_r_factor_is_quantity_validator = pyd.validator("r_factor", allow_reuse=True)(validate_unit_factory("RSI"))
+    _gypsum_thickness_is_quantity_validator = pyd.validator("thickness", allow_reuse=True)(
+        validate_quantity_unit_factory("m")
+    )
+    _gypsum_r_factor_is_quantity_validator = pyd.validator("r_factor", allow_reuse=True)(
+        validate_quantity_unit_factory("RSI")
+    )
 
 
 class SheathingV1(BaseOpenEpdHierarchicalSpec):

--- a/src/openepd/model/specs/generated/steel.py
+++ b/src/openepd/model/specs/generated/steel.py
@@ -13,13 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from typing import Annotated
+
 from openepd.compat.pydantic import pyd
 from openepd.model.base import BaseOpenEpdSchema
-from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec, BaseOpenEpdSpec
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec, BaseOpenEpdSpec, CodegenSpec
 from openepd.model.specs.generated.enums import SteelComposition, SteelRebarGrade
 from openepd.model.standard import Standard
 from openepd.model.validation.numbers import RatioFloat
-from openepd.model.validation.quantity import LengthMmStr, PressureMPaStr, validate_unit_factory
+from openepd.model.validation.quantity import LengthMmStr, PressureMPaStr, validate_quantity_unit_factory
 
 
 class SteelMakingRoute(BaseOpenEpdSchema):
@@ -185,10 +187,10 @@ class StructuralSteelV1(BaseOpenEpdHierarchicalSpec):
     )
 
     _steel_thermal_expansion_is_quantity_validator = pyd.validator("thermal_expansion", allow_reuse=True)(
-        validate_unit_factory("1 / K")
+        validate_quantity_unit_factory("1 / K")
     )
     _steel_thermal_conductivity_is_quantity_validator = pyd.validator("thermal_conductivity", allow_reuse=True)(
-        validate_unit_factory("W / (m * K)")
+        validate_quantity_unit_factory("W / (m * K)")
     )
 
     # Nested specs:
@@ -252,6 +254,7 @@ class SteelV1(BaseOpenEpdHierarchicalSpec):
         default=None, description="Increase in length at break, in percent. Typically 10%-20%", example=0.2
     )
     recycled_content: RatioFloat | None = pyd.Field(default=None, description="", example=0.5, ge=0, le=1)
+    # todo look how to pass validation down to range fields
     post_consumer_recycled_content: RatioFloat | None = pyd.Field(
         default=None,
         description="Should be a number between zero and the Recycled Content (steel_recycled_content)",
@@ -271,7 +274,9 @@ class SteelV1(BaseOpenEpdHierarchicalSpec):
     cold_finished: bool | None = pyd.Field(default=None, example=True)
     galvanized: bool | None = pyd.Field(default=None, example=True)
     stainless: bool | None = pyd.Field(default=None, example=True)
-    making_route: SteelMakingRoute | None = pyd.Field(default=None)
+    making_route: Annotated[SteelMakingRoute | None, CodegenSpec(override_type=SteelMakingRoute)] = pyd.Field(
+        default=None
+    )
     astm_standards: list[Standard] | None = pyd.Field(default=None, description="List of ASTM standards")
     sae_standards: list[Standard] | None = pyd.Field(default=None, description="List of SAE standards")
     en_standards: list[Standard] | None = pyd.Field(default=None, description="List of EN standards")

--- a/src/openepd/model/specs/range/__init__.py
+++ b/src/openepd/model/specs/range/__init__.py
@@ -1,0 +1,101 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("SpecsRange",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+from .accessories import AccessoriesRangeV1
+from .aggregates import AggregatesRangeV1
+from .aluminium import AluminiumRangeV1
+from .asphalt import AsphaltRangeV1
+from .bulk_materials import BulkMaterialsRangeV1
+from .cast_decks_and_underlayment import CastDecksAndUnderlaymentRangeV1
+from .cladding import CladdingRangeV1
+from .cmu import CMURangeV1
+from .concrete import ConcreteRangeV1
+from .conveying_equipment import ConveyingEquipmentRangeV1
+from .electrical import ElectricalRangeV1
+from .electrical_transmission_and_distribution_equipment import ElectricalTransmissionAndDistributionEquipmentRangeV1
+from .electricity import ElectricityRangeV1
+from .finishes import FinishesRangeV1
+from .fire_and_smoke_protection import FireAndSmokeProtectionRangeV1
+from .furnishings import FurnishingsRangeV1
+from .grouting import GroutingRangeV1
+from .manufacturing_inputs import ManufacturingInputsRangeV1
+from .masonry import MasonryRangeV1
+from .material_handling import MaterialHandlingRangeV1
+from .mechanical import MechanicalRangeV1
+from .mechanical_insulation import MechanicalInsulationRangeV1
+from .network_infrastructure import NetworkInfrastructureRangeV1
+from .openings import OpeningsRangeV1
+from .other_electrical_equipment import OtherElectricalEquipmentRangeV1
+from .other_materials import OtherMaterialsRangeV1
+from .plumbing import PlumbingRangeV1
+from .precast_concrete import PrecastConcreteRangeV1
+from .sheathing import SheathingRangeV1
+from .steel import SteelRangeV1
+from .thermal_moisture_protection import ThermalMoistureProtectionRangeV1
+from .utility_piping import UtilityPipingRangeV1
+from .wood import WoodRangeV1
+from .wood_joists import WoodJoistsRangeV1
+
+
+class SpecsRange(BaseOpenEpdHierarchicalSpec):
+    """
+    Material specific specs.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    CMU: CMURangeV1 | None = None
+    Masonry: MasonryRangeV1 | None = None
+    Steel: SteelRangeV1 | None = None
+    NetworkInfrastructure: NetworkInfrastructureRangeV1 | None = None
+    Finishes: FinishesRangeV1 | None = None
+    ManufacturingInputs: ManufacturingInputsRangeV1 | None = None
+    Accessories: AccessoriesRangeV1 | None = None
+    ElectricalTransmissionAndDistributionEquipment: ElectricalTransmissionAndDistributionEquipmentRangeV1 | None = None
+    Aggregates: AggregatesRangeV1 | None = None
+    ThermalMoistureProtection: ThermalMoistureProtectionRangeV1 | None = None
+    Mechanical: MechanicalRangeV1 | None = None
+    Aluminium: AluminiumRangeV1 | None = None
+    Cladding: CladdingRangeV1 | None = None
+    FireAndSmokeProtection: FireAndSmokeProtectionRangeV1 | None = None
+    PrecastConcrete: PrecastConcreteRangeV1 | None = None
+    Asphalt: AsphaltRangeV1 | None = None
+    OtherMaterials: OtherMaterialsRangeV1 | None = None
+    Plumbing: PlumbingRangeV1 | None = None
+    Electrical: ElectricalRangeV1 | None = None
+    UtilityPiping: UtilityPipingRangeV1 | None = None
+    BulkMaterials: BulkMaterialsRangeV1 | None = None
+    CastDecksAndUnderlayment: CastDecksAndUnderlaymentRangeV1 | None = None
+    Concrete: ConcreteRangeV1 | None = None
+    Sheathing: SheathingRangeV1 | None = None
+    Furnishings: FurnishingsRangeV1 | None = None
+    Wood: WoodRangeV1 | None = None
+    ConveyingEquipment: ConveyingEquipmentRangeV1 | None = None
+    MaterialHandling: MaterialHandlingRangeV1 | None = None
+    Openings: OpeningsRangeV1 | None = None
+    Electricity: ElectricityRangeV1 | None = None
+    Grouting: GroutingRangeV1 | None = None
+    MechanicalInsulation: MechanicalInsulationRangeV1 | None = None
+    OtherElectricalEquipment: OtherElectricalEquipmentRangeV1 | None = None
+    WoodJoists: WoodJoistsRangeV1 | None = None

--- a/src/openepd/model/specs/range/accessories.py
+++ b/src/openepd/model/specs/range/accessories.py
@@ -1,0 +1,97 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "BlanketFacingRangeV1",
+    "DoorsHardwareRangeV1",
+    "FlooringAccessoriesRangeV1",
+    "MortarRangeV1",
+    "TileGroutRangeV1",
+    "AccessoriesRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class BlanketFacingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Facing materials for insulation products.
+
+    Such as kraft, white vinyl sheeting, or aluminum foil, which can serve as air barrier, vapor barrier, radiant
+    barrier, or flame resistive layer.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class DoorsHardwareRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Door hardware, including automatic and security door hardware.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FlooringAccessoriesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Products used in flooring, other than the actual flooring product itself.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MortarRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious paste used to bind building blocks such as stones, bricks, and concrete masonry.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class TileGroutRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Water-cement-sand mixture for laying ceramic tile.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AccessoriesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Materials that are used alongside other materials.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    BlanketFacing: BlanketFacingRangeV1 | None = None
+    DoorsHardware: DoorsHardwareRangeV1 | None = None
+    FlooringAccessories: FlooringAccessoriesRangeV1 | None = None
+    Mortar: MortarRangeV1 | None = None
+    TileGrout: TileGroutRangeV1 | None = None

--- a/src/openepd/model/specs/range/aggregates.py
+++ b/src/openepd/model/specs/range/aggregates.py
@@ -1,0 +1,57 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("AggregatesRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.aggregates import AggregateApplication
+from openepd.model.specs.generated.enums import AggregateGradation, AggregateWeightClassification
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class AggregatesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Construction Aggregates.
+
+    Includes sand, gravel, crushed stone, etc. for use as bases, ballasts, or as a component in concrete or asphalt.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    recycled_content: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Percent of total mass that is recycled aggregate"
+    )
+    nominal_max_size: AmountRangeLengthMm | None = pyd.Field(
+        default=None,
+        description="Nominal maximum aggregate size is defined as one sieve size smaller than the maximum aggregate size. The maximum aggregate size is defined as the smallest sieve size that requires 100% passing.",
+    )
+    weight_classification: list[AggregateWeightClassification] | None = pyd.Field(default=None)
+    gradation: list[AggregateGradation] | None = pyd.Field(default=None)
+    manufactured: bool | None = pyd.Field(
+        default=None,
+        description="Aggregate produced via expansion or sintering at high temperatures of the following materials: clay, shale, slate, perlite, vermiculite, or slag. Typically used to produce lightweight aggregate",
+    )
+    slag: bool | None = pyd.Field(
+        default=None,
+        description="Pelletized, foamed, and granulated blast furnace slag can be used as construction aggregate.",
+    )
+    application: AggregateApplication | None = None

--- a/src/openepd/model/specs/range/aluminium.py
+++ b/src/openepd/model/specs/range/aluminium.py
@@ -1,0 +1,92 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "AluminiumBilletsRangeV1",
+    "AluminiumExtrusionsRangeV1",
+    "AluminiumSheetGoodsRangeV1",
+    "AluminiumSuspensionAssemblyRangeV1",
+    "AluminiumRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import AluminiumAlloy
+
+
+class AluminiumBilletsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cast Aluminium ingots or billets for use in manufacturing more finished products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AluminiumExtrusionsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Extruded aluminum products used in construction.
+
+    Includes range of finish options including mill finish, painted, and anodized.
+
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thermally_improved: bool | None = pyd.Field(default=None, description="")
+
+
+class AluminiumSheetGoodsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Rolled and/or Stamped Aluminium coil or sheets, often used in flashing, trim, panels, and deck.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AluminiumSuspensionAssemblyRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Aluminum suspension assemblies for acoustical ceiling systems.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AluminiumRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Broad category for construction materials made primarily from Aluminium and its alloys.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    alloy: list[AluminiumAlloy] | None = pyd.Field(default=None, description="")
+    anodized: bool | None = pyd.Field(default=None, description="")
+    painted: bool | None = pyd.Field(default=None, description="")
+    AluminiumBillets: AluminiumBilletsRangeV1 | None = None
+    AluminiumExtrusions: AluminiumExtrusionsRangeV1 | None = None
+    AluminiumSheetGoods: AluminiumSheetGoodsRangeV1 | None = None
+    AluminiumSuspensionAssembly: AluminiumSuspensionAssemblyRangeV1 | None = None

--- a/src/openepd/model/specs/range/asphalt.py
+++ b/src/openepd/model/specs/range/asphalt.py
@@ -1,0 +1,61 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("AsphaltRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import AsphaltGradation, AsphaltMixType
+from openepd.model.validation.quantity import AmountRangeLengthMm, AmountRangeTemperatureC
+
+
+class AsphaltRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    General category for asphalt mixtures.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    aggregate_size_max: AmountRangeLengthMm | None = pyd.Field(default=None, description="Max aggregate size")
+    rap: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Percent of mixture that has been replaced by recycled asphalt pavement (RAP)."
+    )
+    ras: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Percent of mixture that has been replaced by recycled asphalt shingles (RAS)."
+    )
+    ground_tire_rubber: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Percent of mixture that has been replaced by ground tire rubber (GTR)."
+    )
+    max_temperature: AmountRangeTemperatureC | None = pyd.Field(
+        default=None,
+        description="The upper threshold temperature to which an asphalt binder can be heated preventing the asphalt mixture from rutting",
+    )
+    min_temperature: AmountRangeTemperatureC | None = pyd.Field(
+        default=None,
+        description="The lower threshold temperature for an asphalt binder to prevent thermal cracking of the asphalt mixture.",
+    )
+    mix_type: list[AsphaltMixType] | None = pyd.Field(default=None, description="Asphalt mix type")
+    gradation: list[AsphaltGradation] | None = pyd.Field(default=None, description="Asphalt gradation")
+    sbr: bool | None = pyd.Field(default=None, description="Styrene-butadiene rubber (SBR)")
+    sbs: bool | None = pyd.Field(default=None, description="Styrene-butadiene-styrene (SBS)")
+    ppa: bool | None = pyd.Field(default=None, description="Polyphosphoric acid (PPA)")
+    gtr: bool | None = pyd.Field(default=None, description="Ground tire rubber (GTR)")
+    pmb: bool | None = pyd.Field(default=None, description="Polymer modified bitumen (PMB)")

--- a/src/openepd/model/specs/range/bulk_materials.py
+++ b/src/openepd/model/specs/range/bulk_materials.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("BulkMaterialsRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class BulkMaterialsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    A generic category for materials whose declared unit is mass and which are not in another category.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"

--- a/src/openepd/model/specs/range/cast_decks_and_underlayment.py
+++ b/src/openepd/model/specs/range/cast_decks_and_underlayment.py
@@ -1,0 +1,34 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("CastDecksAndUnderlaymentRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class CastDecksAndUnderlaymentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cast roof deck substrate systems.
+
+    Typically made of gyspum concrete or cementitious wood fiber, that provide structural support to
+    roofing materials.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"

--- a/src/openepd/model/specs/range/cladding.py
+++ b/src/openepd/model/specs/range/cladding.py
@@ -1,0 +1,275 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "AluminiumSidingRangeV1",
+    "SteelSidingRangeV1",
+    "ZincSidingRangeV1",
+    "ShingleAndShakeSidingRangeV1",
+    "MetalSidingRangeV1",
+    "CompositionSidingRangeV1",
+    "FiberCementSidingRangeV1",
+    "InsulatedVinylSidingRangeV1",
+    "PlywoodSidingRangeV1",
+    "PolypropyleneSidingRangeV1",
+    "SolidWoodSidingRangeV1",
+    "VinylSidingRangeV1",
+    "SidingRangeV1",
+    "InsulatedRoofPanelsRangeV1",
+    "InsulatedWallPanelsRangeV1",
+    "RoofPanelsRangeV1",
+    "StoneCladdingRangeV1",
+    "WallPanelsRangeV1",
+    "CladdingRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import CladdingFacingMaterial, CladdingInsulatingMaterial, SidingFormFactor
+from openepd.model.validation.quantity import AmountRangeLengthMm, AmountRangeRValue
+
+
+class AluminiumSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior siding product made primarily from aluminium.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SteelSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior siding product made primarily from steel.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ZincSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior siding product made primarily from zinc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ShingleAndShakeSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Shingle & shake siding.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MetalSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior siding product made of metal such as steel, aluminum, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AluminiumSiding: AluminiumSidingRangeV1 | None = None
+    SteelSiding: SteelSidingRangeV1 | None = None
+    ZincSiding: ZincSidingRangeV1 | None = None
+
+
+class CompositionSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Composite wood siding composed of wood wafers and resin.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FiberCementSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Composite siding product made of cement and cellulose fibers.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class InsulatedVinylSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Vinyl cladding product integrated with manufacturer-installed insulation.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class PlywoodSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Siding made of plywood boards.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PolypropyleneSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior wall cladding made from polypropylene, which may contain fillers or reinforcements.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SolidWoodSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Siding products made of wood including shingle & shake siding.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    ShingleAndShakeSiding: ShingleAndShakeSidingRangeV1 | None = None
+
+
+class VinylSidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exterior wall cladding made principally from rigid polyvinyl chloride (PVC).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class SidingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Long narrow products for exterior wall face of building.
+
+    Typically made of, e.g., metal, solid wood, plywood, plastic, composition, fiber cement, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    insulated: bool | None = pyd.Field(default=None, description="")
+    ventilated: bool | None = pyd.Field(default=None, description="")
+    paint_or_stain_required: bool | None = pyd.Field(default=None, description="")
+    r_value: AmountRangeRValue | None = pyd.Field(default=None, description="")
+    form_factor: list[SidingFormFactor] | None = pyd.Field(default=None, description="")
+    MetalSiding: MetalSidingRangeV1 | None = None
+    CompositionSiding: CompositionSidingRangeV1 | None = None
+    FiberCementSiding: FiberCementSidingRangeV1 | None = None
+    InsulatedVinylSiding: InsulatedVinylSidingRangeV1 | None = None
+    PlywoodSiding: PlywoodSidingRangeV1 | None = None
+    PolypropyleneSiding: PolypropyleneSidingRangeV1 | None = None
+    SolidWoodSiding: SolidWoodSidingRangeV1 | None = None
+    VinylSiding: VinylSidingRangeV1 | None = None
+
+
+class InsulatedRoofPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Insulated roof panels performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    r_value: AmountRangeRValue | None = pyd.Field(default=None, description="")
+    insulating_material: list[CladdingInsulatingMaterial] | None = pyd.Field(default=None, description="")
+
+
+class InsulatedWallPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Insulated wall panels performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    r_value: AmountRangeRValue | None = pyd.Field(default=None, description="")
+    insulating_material: list[CladdingInsulatingMaterial] | None = pyd.Field(default=None, description="")
+
+
+class RoofPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Roof panels performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class StoneCladdingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Stone cladding performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WallPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wall panels performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CladdingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cladding performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    facing_material: list[CladdingFacingMaterial] | None = pyd.Field(default=None, description="")
+    Siding: SidingRangeV1 | None = None
+    InsulatedRoofPanels: InsulatedRoofPanelsRangeV1 | None = None
+    InsulatedWallPanels: InsulatedWallPanelsRangeV1 | None = None
+    RoofPanels: RoofPanelsRangeV1 | None = None
+    StoneCladding: StoneCladdingRangeV1 | None = None
+    WallPanels: WallPanelsRangeV1 | None = None

--- a/src/openepd/model/specs/range/cmu.py
+++ b/src/openepd/model/specs/range/cmu.py
@@ -1,0 +1,44 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("CMURangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import CmuBlockType, CmuWeightClassification
+from openepd.model.validation.quantity import AmountRangeGWP, AmountRangePressureMpa
+
+
+class CMURangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Pre-manufactured concrete masonry blocks.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    white_cement: bool | None = pyd.Field(default=None, description="")
+    strength_28d: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    weight_classification: list[CmuWeightClassification] | None = pyd.Field(default=None, description="")
+    block_type: list[CmuBlockType] | None = pyd.Field(default=None, description="")
+    insulated: bool | None = pyd.Field(default=None, description="")
+    sound_performance: bool | None = pyd.Field(default=None, description="")
+    b1_recarbonation: AmountRangeGWP | None = pyd.Field(default=None, description="")
+    b1_recarbonation_z: RangeFloat | None = pyd.Field(default=None, description="")

--- a/src/openepd/model/specs/range/concrete.py
+++ b/src/openepd/model/specs/range/concrete.py
@@ -1,0 +1,179 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "CementGroutRangeV1",
+    "ConcretePavingRangeV1",
+    "FlowableFillRangeV1",
+    "OilPatchRangeV1",
+    "ReadyMixRangeV1",
+    "ShotcreteRangeV1",
+    "ConcreteRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from typing import Literal
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.concrete import Cementitious, ConcreteTypicalApplication
+from openepd.model.specs.generated.enums import AciExposureClass, CsaExposureClass, EnExposureClass
+from openepd.model.validation.quantity import (
+    AmountRangeLengthInch,
+    AmountRangeLengthMm,
+    AmountRangeMass,
+    AmountRangePressureMpa,
+)
+
+
+class CementGroutRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cement grout performance specification.
+
+    Cement grouting is a slurry that is placed as a flowable liquid. It is an effective material
+    for filling and strengthening granular soils, voids in rocks, foundation underpinnings, and
+    other underground voids. Also called structural grout, these materials typically impart
+    significant compressive strength to the system.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ConcretePavingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Concrete paving.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    flexion_strength: AmountRangePressureMpa | None = pyd.Field(default=None, description="Concrete flexural strength.")
+
+
+class FlowableFillRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Flowable fill performance specification.
+
+    Flowable fill is a slurry that is placed as a flowable liquid (high slump) and sets with no
+    compaction. It is often used in tight or restricted access areas where placing and compacting
+    fill is difficult. Applications include filling large voids such as abandoned underground storage
+    tanks, basements, tunnels, mines, and sewers. It can also be used as paving sub-base, bridge
+    abutment, and retaining wall backfill.
+
+    Also called Controlled Density Fill (CDF) or Controlled Low Strength Materials (CLSMs). These materials typically
+    have compressive strengths under 1200 psi.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OilPatchRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Petroleum Industry Cement Slurry.
+
+    Concretes for use in creation, maintenance, and decommissioning of petroleum extraction wells and similar
+    applications. Includes foamed cement; often called cement in the drilling industry. Differs from
+    flowable fill and grout in that it contains no sand or other aggregates.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ReadyMixRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Concretes to be mixed and then poured on-site.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ShotcreteRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Concretes sprayed on a target.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ConcreteRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Concrete.
+
+    A composite material composed of fine and coarse aggregate bonded together with a fluid cement (cement paste) that
+    hardens over time.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    lightweight: bool | None = pyd.Field(default=None, description="Product is lightweight")
+    strength_28d: AmountRangePressureMpa | None = pyd.Field(default=None, description="Concrete strength after 28 days")
+    strength_other: AmountRangePressureMpa | None = pyd.Field(
+        default=None, description="A strength spec which is to be reached later other 28 days (e.g. 42d)"
+    )
+    strength_other_d: Literal[3, 7, 14, 42, 56, 72, 96, 120] | None = pyd.Field(
+        default=None, description="Test Day for strength_other"
+    )
+    slump: AmountRangeLengthInch | None = pyd.Field(default=None, description="")
+    min_slump: AmountRangeLengthInch | None = pyd.Field(default=None, description="Minimum test slump")
+    max_slump: AmountRangeLengthInch | None = pyd.Field(default=None, description="")
+    min_pipeline_size: AmountRangeLengthMm | None = pyd.Field(default=None, description="Minimum pipeline size")
+    w_c_ratio: RangeRatioFloat | None = pyd.Field(default=None, description="Ratio of water to cement")
+    air_entrain: bool | None = pyd.Field(default=None, description="Air Entrainment")
+    co2_entrain: bool | None = pyd.Field(default=None, description="CO2 Curing")
+    self_consolidating: bool | None = pyd.Field(default=None, description="Self Compacting")
+    white_cement: bool | None = pyd.Field(default=None, description="White Cement")
+    plc: bool | None = pyd.Field(default=None, description="Portland Limestone Cement")
+    finishable: bool | None = pyd.Field(default=None, description="Finishable")
+    fiber_reinforced: bool | None = pyd.Field(default=None, description="fiber_reinforced")
+    cementitious: Cementitious | None = pyd.Field(
+        default=None, description="List of cementitious materials, and proportion by mass"
+    )
+    aggregate_size_max: AmountRangeLengthMm | None = pyd.Field(
+        default=None,
+        description="The smallest sieve size for which the entire amount of aggregate is able to pass. Parameter describes diameter of aggregate",
+    )
+    cement_content: AmountRangeMass | None = pyd.Field(default=None)
+    aci_exposure_classes: list[AciExposureClass] | None = pyd.Field(
+        default=None, description="List of ACI exposure classes"
+    )
+    csa_exposure_classes: list[CsaExposureClass] | None = pyd.Field(
+        default=None, description="List of CSA exposure classes"
+    )
+    en_exposure_classes: list[EnExposureClass] | None = pyd.Field(
+        default=None, description="List of EN exposure classes"
+    )
+    typical_application: ConcreteTypicalApplication | None = pyd.Field(default=None, description="Typical Application")
+    CementGrout: CementGroutRangeV1 | None = None
+    ConcretePaving: ConcretePavingRangeV1 | None = None
+    FlowableFill: FlowableFillRangeV1 | None = None
+    OilPatch: OilPatchRangeV1 | None = None
+    ReadyMix: ReadyMixRangeV1 | None = None
+    Shotcrete: ShotcreteRangeV1 | None = None

--- a/src/openepd/model/specs/range/conveying_equipment.py
+++ b/src/openepd/model/specs/range/conveying_equipment.py
@@ -1,0 +1,86 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "EscalatorsRangeV1",
+    "ElevatorsRangeV1",
+    "ConveyingEquipmentRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import ElevatorsBuildingRise, ElevatorsUsageIntensity
+from openepd.model.validation.quantity import (
+    AmountRangeCapacityPerHour,
+    AmountRangeLengthMm,
+    AmountRangeMass,
+    AmountRangeSpeed,
+)
+
+
+class EscalatorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Escalators category performance specification.
+
+    A moving staircase consisting of a circulating belt of steps driven by a motor,
+    which conveys people between the floors of a building.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    vertical_rise: AmountRangeLengthMm | None = pyd.Field(
+        default=None, description="The vertical distance between the top and bottom landings of an escalator"
+    )
+    speed: AmountRangeSpeed | None = pyd.Field(default=None, description="Reference speed of the escalator")
+    step_width: AmountRangeLengthMm | None = pyd.Field(default=None, description="Width of the escalator steps")
+    max_capacity: AmountRangeCapacityPerHour | None = pyd.Field(
+        default=None, description="Max capacity of escalator in persons per hour"
+    )
+    indoor: bool | None = pyd.Field(default=None, description="Escalator can be used for indoor applications")
+    outdoor: bool | None = pyd.Field(default=None, description="Escalator can be used for outdoor applications")
+
+
+class ElevatorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Car that moves in a vertical shaft to carry passengers or freight between the levels of a multistory building.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    usage_intensity: list[ElevatorsUsageIntensity] | None = pyd.Field(default=None, description="")
+    travel_length: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    rated_load: AmountRangeMass | None = pyd.Field(default=None, description="")
+    rated_speed: AmountRangeSpeed | None = pyd.Field(default=None, description="")
+    building_rise: list[ElevatorsBuildingRise] | None = pyd.Field(default=None, description="")
+
+
+class ConveyingEquipmentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Conveying Equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    Elevators: ElevatorsRangeV1 | None = None
+    Escalators: EscalatorsRangeV1 | None = None

--- a/src/openepd/model/specs/range/electrical.py
+++ b/src/openepd/model/specs/range/electrical.py
@@ -1,0 +1,422 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "LowVoltBusesRangeV1",
+    "MedVoltBusesRangeV1",
+    "BatteriesRangeV1",
+    "OtherElectricalPowerStorageRangeV1",
+    "CableTraysRangeV1",
+    "ElectricalBusesRangeV1",
+    "FloorEquipmentBoxesRangeV1",
+    "PowerDistributionUnitsRangeV1",
+    "RacewaysRangeV1",
+    "FueledElectricalGeneratorsRangeV1",
+    "OtherGenerationRangeV1",
+    "PhotovoltaicsRangeV1",
+    "WindTurbinesRangeV1",
+    "ElectricityFromPowerGridRangeV1",
+    "ElectricityFromSpecificGeneratorRangeV1",
+    "PowerPurchaseAgreementsRangeV1",
+    "LightbulbsRangeV1",
+    "LightingControlsRangeV1",
+    "LightingFixturesRangeV1",
+    "OutdoorLightingRangeV1",
+    "SpecialtyLightingRangeV1",
+    "TaskLightingRangeV1",
+    "ElectricalPowerStorageRangeV1",
+    "LowVoltageElectricalDistributionRangeV1",
+    "ElectricalGenerationEquipmentRangeV1",
+    "ElectricPowerRangeV1",
+    "LightingRangeV1",
+    "ElectricalConduitRangeV1",
+    "ElectricalRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import CableTraysMaterial, ConduitMaterial, EnergySource, RacewaysMaterial
+from openepd.model.validation.quantity import (
+    AmountRangeColorTemperature,
+    AmountRangeLengthMm,
+    AmountRangeLuminosity,
+    AmountRangeMass,
+    AmountRangePower,
+)
+
+
+class LowVoltBusesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Busbars and Busways of 600V or less.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MedVoltBusesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Busbars and Busways over 600V.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class BatteriesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Battery equipment, including central batteries, battery charging, and UPS.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OtherElectricalPowerStorageRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other electrical power storage performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CableTraysRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Mechanical support for electrial or communications cabling, typically suspended from a roof or wall.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    height: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    depth: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    static_load: AmountRangeMass | None = pyd.Field(default=None, description="")
+    ventilated: bool | None = pyd.Field(default=None, description="At least 40% of the tray base is open to air flow")
+    cable_trays_material: list[CableTraysMaterial] | None = pyd.Field(default=None, description="")
+
+
+class ElectricalBusesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Power distribution, in the form of busbars or of insulted ducts made of copper or aluminum busbars.
+
+    It is an alternative means of conducting electricity compared toto power cables or cable bus. Also called
+    bus ducts.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    LowVoltBuses: LowVoltBusesRangeV1 | None = None
+    MedVoltBuses: MedVoltBusesRangeV1 | None = None
+
+
+class FloorEquipmentBoxesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Equipment boxes for power or electronic equipment embedded in an accessible floor.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PowerDistributionUnitsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Switched electrical distribution units placed very close to the point of consumption, for example inside a rack of electronic equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class RacewaysRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Mechanical guideways for eletrical communications cabling, typically embedded in an accessible floor.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    depth: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    painted: bool | None = pyd.Field(default=None, description="")
+    divided: bool | None = pyd.Field(default=None, description="")
+    raceways_material: list[RacewaysMaterial] | None = pyd.Field(default=None, description="")
+
+
+class FueledElectricalGeneratorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fueled electrical generators.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OtherGenerationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other generation.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PhotovoltaicsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Solar photovoltaics, rated on a nameplate capacity basis.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WindTurbinesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wind generators, rated on a nameplate capacity basis.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricityFromPowerGridRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical energy drawn from a specific utility grid.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricityFromSpecificGeneratorRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical energy from a specific power plant, such as a wind farm using a specific type of turbine.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    energy_source: list[EnergySource] | None = pyd.Field(default=None, description="")
+
+
+class PowerPurchaseAgreementsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical energy subject to a verified power purchase agreement.
+
+    The impact of electricity generation is allocated specifically to the agreement and not to the general grid.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    energy_source: list[EnergySource] | None = pyd.Field(default=None, description="")
+
+
+class LightbulbsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Various types of light bulbs, including LED, CFL, halogen, and incandescent.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class LightingControlsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Devices used to control the operation of lighting, including dimmers, sensors, and smart controls.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class LightingFixturesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Permanent lighting fixtures for interior spaces, including ceiling, wall-mounted, and pendant fixtures.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OutdoorLightingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Lighting products designed for outdoor use, including landscape and security lighting.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SpecialtyLightingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Specialized lighting for niche applications like emergency, medical, or theatrical lighting.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class TaskLightingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Lighting designed for specific tasks such as desk lamps, under-cabinet lighting, and reading lamps.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricalPowerStorageRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical Power Storage.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Batteries: BatteriesRangeV1 | None = None
+    OtherElectricalPowerStorage: OtherElectricalPowerStorageRangeV1 | None = None
+
+
+class LowVoltageElectricalDistributionRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Low Voltage Electrical Distribution.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    CableTrays: CableTraysRangeV1 | None = None
+    ElectricalBuses: ElectricalBusesRangeV1 | None = None
+    FloorEquipmentBoxes: FloorEquipmentBoxesRangeV1 | None = None
+    PowerDistributionUnits: PowerDistributionUnitsRangeV1 | None = None
+    Raceways: RacewaysRangeV1 | None = None
+
+
+class ElectricalGenerationEquipmentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Equipment for generating electrical power.
+
+    This category is primarily for smaller-scale. (e.g. on premises) generation, rather than utility-scale equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    FueledElectricalGenerators: FueledElectricalGeneratorsRangeV1 | None = None
+    OtherGeneration: OtherGenerationRangeV1 | None = None
+    Photovoltaics: PhotovoltaicsRangeV1 | None = None
+    WindTurbines: WindTurbinesRangeV1 | None = None
+
+
+class ElectricPowerRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical energy drawn from a utility grid.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    ElectricityFromPowerGrid: ElectricityFromPowerGridRangeV1 | None = None
+    ElectricityFromSpecificGenerator: ElectricityFromSpecificGeneratorRangeV1 | None = None
+    PowerPurchaseAgreements: PowerPurchaseAgreementsRangeV1 | None = None
+
+
+class LightingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Lamps and lightbulbs and lamp components.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    color_temperature: AmountRangeColorTemperature | None = pyd.Field(default=None, description="")
+    typical_utilization: str | None = pyd.Field(default=None, description="")
+    luminosity: AmountRangeLuminosity | None = pyd.Field(default=None, description="")
+    wattage: AmountRangePower | None = pyd.Field(default=None, description="")
+    color_rendering_index: RangeFloat | None = pyd.Field(default=None, description="")
+    dimmable: bool | None = pyd.Field(default=None, description="")
+    Lightbulbs: LightbulbsRangeV1 | None = None
+    LightingControls: LightingControlsRangeV1 | None = None
+    LightingFixtures: LightingFixturesRangeV1 | None = None
+    OutdoorLighting: OutdoorLightingRangeV1 | None = None
+    SpecialtyLighting: SpecialtyLightingRangeV1 | None = None
+    TaskLighting: TaskLightingRangeV1 | None = None
+
+
+class ElectricalConduitRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Tubing used to protect and route electrical wiring in a building or structure.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    nominal_diameter: AmountRangeLengthMm | None = None
+    outer_diameter: AmountRangeLengthMm | None = None
+    inner_diameter: AmountRangeLengthMm | None = None
+    wall_thickness: AmountRangeLengthMm | None = None
+    material: list[ConduitMaterial] | None = None
+
+
+class ElectricalRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electric power and equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    ElectricalPowerStorage: ElectricalPowerStorageRangeV1 | None = None
+    LowVoltageElectricalDistribution: LowVoltageElectricalDistributionRangeV1 | None = None
+    ElectricalGenerationEquipment: ElectricalGenerationEquipmentRangeV1 | None = None
+    ElectricPower: ElectricPowerRangeV1 | None = None
+    Lighting: LightingRangeV1 | None = None
+    ElectricalConduit: ElectricalConduitRangeV1 | None = None

--- a/src/openepd/model/specs/range/electrical_transmission_and_distribution_equipment.py
+++ b/src/openepd/model/specs/range/electrical_transmission_and_distribution_equipment.py
@@ -1,0 +1,96 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "AcTransformersRangeV1",
+    "ElectricalInsulatorsRangeV1",
+    "ElectricalSubstationsRangeV1",
+    "ElectricalSwitchgearRangeV1",
+    "PowerCablingRangeV1",
+    "ElectricalTransmissionAndDistributionEquipmentRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class AcTransformersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Equipment for transforming between higher and lower voltage AC power.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricalInsulatorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Passive electrical isolation.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricalSubstationsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical substations performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricalSwitchgearRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Equipment for interrupting and controlling high-power electrical flows.
+
+    Used for protection, isolation, or control of electrical equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PowerCablingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    High-voltage electrical cabling.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ElectricalTransmissionAndDistributionEquipmentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical Transmission & Distribution Equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AcTransformers: AcTransformersRangeV1 | None = None
+    ElectricalInsulators: ElectricalInsulatorsRangeV1 | None = None
+    ElectricalSubstations: ElectricalSubstationsRangeV1 | None = None
+    ElectricalSwitchgear: ElectricalSwitchgearRangeV1 | None = None
+    PowerCabling: PowerCablingRangeV1 | None = None

--- a/src/openepd/model/specs/range/electricity.py
+++ b/src/openepd/model/specs/range/electricity.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("ElectricityRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class ElectricityRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical equipment and components and supplies.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"

--- a/src/openepd/model/specs/range/finishes.py
+++ b/src/openepd/model/specs/range/finishes.py
@@ -1,0 +1,585 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "AccessFlooringRangeV1",
+    "CarpetRangeV1",
+    "LaminateRangeV1",
+    "OtherFlooringRangeV1",
+    "ResilientFlooringRangeV1",
+    "WallBaseRangeV1",
+    "WoodFlooringRangeV1",
+    "AcousticalCeilingsRangeV1",
+    "CeramicTileRangeV1",
+    "GaugedTileRangeV1",
+    "GlassTileRangeV1",
+    "GypsumSupportsRangeV1",
+    "FlooringRangeV1",
+    "CeilingPanelRangeV1",
+    "BackingAndUnderlayRangeV1",
+    "CementBoardRangeV1",
+    "TilingRangeV1",
+    "DeckingBoardsRangeV1",
+    "GlassFiberReinforcedGypsumFabricationsRangeV1",
+    "GypsumRangeV1",
+    "MirrorsRangeV1",
+    "PaintByMassRangeV1",
+    "PaintByVolumeRangeV1",
+    "PaintByAreaRangeV1",
+    "PaintingAndCoatingRangeV1",
+    "WallFinishesRangeV1",
+    "PlasterRangeV1",
+    "FinishesRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeAmount, RangeFloat, RangeInt, RangeRatioFloat
+from openepd.model.org import OrgRef
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    AccessFlooringCoreMaterial,
+    AccessFlooringFinishMaterial,
+    AccessFlooringSeismicRating,
+    AccessFlooringStringers,
+    AllFabrication,
+    CarpetFormFactor,
+    CarpetIntendedApplication,
+    CarpetManufactureType,
+    CarpetYarnType,
+    CeilingPanelCoreMaterial,
+    CeilingPanelFireRating,
+    CementBoardThickness,
+    DeckingBoardMaterial,
+    GypsumFacing,
+    GypsumFireRating,
+    GypsumThickness,
+    PlasterComposition,
+    ResilientFlooringFormFactor,
+    ResilientFlooringMaterial,
+    ResilientFlooringThickness,
+    SawnTimberSpecies,
+    VinylSheetConstruction,
+    WallBaseMaterial,
+    WoodFlooringFabrication,
+    WoodFlooringTimberSpecies,
+)
+from openepd.model.validation.quantity import AmountRangeGWP, AmountRangeLengthMm, AmountRangePressureMpa
+
+
+class AccessFlooringRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Elevated floor system built on top of concrete slab surface.
+
+    It thereby creates a hidden void between the two floors that is used for the passage of mechanical and electrical
+    services. The system consists of panels, stringers, and pedestals.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    core_material: list[AccessFlooringCoreMaterial] | None = pyd.Field(default=None, description="")
+    finish_material: list[AccessFlooringFinishMaterial] | None = pyd.Field(default=None, description="")
+    stringers: list[AccessFlooringStringers] | None = pyd.Field(default=None, description="")
+    seismic_rating: list[AccessFlooringSeismicRating] | None = pyd.Field(default=None, description="")
+    magnetically_attached_finish: bool | None = pyd.Field(default=None, description="")
+    permanent_finish: bool | None = pyd.Field(default=None, description="")
+    drylay: bool | None = pyd.Field(default=None, description="")
+    adjustable_height: bool | None = pyd.Field(default=None, description="")
+    fixed_height: bool | None = pyd.Field(default=None, description="")
+    finished_floor_height: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    panel_thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    concentrated_load: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    uniform_load: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    rolling_load_10_pass: str | None = pyd.Field(default=None, description="")
+    rolling_load_10000_pass: str | None = pyd.Field(default=None, description="")
+
+
+class CarpetRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Textile Floor Coverings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    length: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    intended_application: list[CarpetIntendedApplication] | None = pyd.Field(default=None, description="")
+    manufacture_type: list[CarpetManufactureType] | None = pyd.Field(default=None, description="")
+    form_factor: list[CarpetFormFactor] | None = pyd.Field(default=None, description="")
+    yarn_weight: str | None = pyd.Field(default=None, description="")
+    yarn_type: list[CarpetYarnType] | None = pyd.Field(default=None, description="")
+    fire_radiant_panel_rating_astme648: str | None = pyd.Field(default=None, description="")
+    fire_smoke_density_rating_astme648: str | None = pyd.Field(default=None, description="")
+    voc_emissions: str | None = pyd.Field(default=None, description="")
+    cushioned: bool | None = pyd.Field(default=None, description="")
+    bleachable: bool | None = pyd.Field(default=None, description="")
+    gwp_factor_base: AmountRangeGWP | None = pyd.Field(default=None, description="")
+    gwp_factor_yarn: AmountRangeGWP | None = pyd.Field(default=None, description="")
+
+
+class LaminateRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Laminate flooring.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OtherFlooringRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other not yet classified kinds of flooring.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ResilientFlooringRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Resilient floor products.
+
+    Includes vinyl, rubber, linoleum, composition cork, etc. in modular square or rectangle shapes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    length: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    form_factor: list[ResilientFlooringFormFactor] | None = pyd.Field(default=None, description="")
+    material: list[ResilientFlooringMaterial] | None = pyd.Field(default=None, description="")
+    sheet_construction: list[VinylSheetConstruction] | None = pyd.Field(default=None, description="")
+    wear_layer: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    delta_iic: RangeFloat | None = pyd.Field(default=None, description="")
+    thickness: list[ResilientFlooringThickness] | None = pyd.Field(default=None, description="")
+    sport_flooring: bool | None = pyd.Field(default=None, description="")
+    conductive_flooring: bool | None = pyd.Field(default=None, description="")
+    zwtl: bool | None = pyd.Field(default=None, description="")
+    floor_score: bool | None = pyd.Field(default=None, description="")
+    nsf332: bool | None = pyd.Field(default=None, description="")
+
+
+class WallBaseRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wall base made to help cover gaps between wall and vinyl, rubber, wood, or tile flooring.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    wall_base_material: list[WallBaseMaterial] | None = pyd.Field(default=None, description="")
+
+
+class WoodFlooringRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wood flooring for interior applications.
+
+    Includes hardwood strip and plank flooring, engineered hardwood flooring, wood parquet flooring, coordinated
+    transitions, and molding pieces.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    forest_practices_certifiers: list[OrgRef] | None = None
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    timber_species: list[WoodFlooringTimberSpecies] | None = pyd.Field(default=None, description="")
+    fabrication: list[WoodFlooringFabrication] | None = pyd.Field(default=None, description="")
+
+
+class AcousticalCeilingsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Acoustical ceiling panels.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class CeramicTileRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Ceramic tiles, including porcelain, quarry, pressed floor tile, wall tile, mosaic tile, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    porcelain: bool | None = pyd.Field(
+        default=None, description="A dense and durable ceramic tile made from fine porcelain clay."
+    )
+    quarry: bool | None = pyd.Field(
+        default=None,
+        description="A type of unglazed ceramic tile made from natural clay with a slightly rough texture.",
+    )
+    pressed_floor_tile: bool | None = pyd.Field(
+        default=None,
+        description="A durable and low-maintenance type of tile made by compressing clay or other materials at high pressure.",
+    )
+    wall_tile: bool | None = pyd.Field(
+        default=None,
+        description="A decorative tile designed for use on vertical surfaces such as walls or backsplashes.",
+    )
+    mosaic_tile: bool | None = pyd.Field(
+        default=None,
+        description="A small decorative tile made of glass, stone, or ceramic, arranged in a pattern to create a design.",
+    )
+    specialty: bool | None = pyd.Field(
+        default=None,
+        description="A unique and customized type of tile, often made from unconventional materials or with specialized designs or finishes.",
+    )
+
+
+class GaugedTileRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Specially manufactured porcelain tile with extra-large panels/slabs.
+
+    Manufactured to a specific thickness ranging from 2-20 mm.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    tile_panels: bool | None = pyd.Field(
+        default=None,
+        description="Large-format porcelain or natural stone tiles that are typically over 3 feet in length and width, designed for use in floor and wall installations to create a seamless and uninterrupted appearance.",
+    )
+    tile_pavers: bool | None = pyd.Field(
+        default=None,
+        description="Thick and durable porcelain or natural stone tiles that are commonly used in outdoor applications, such as patios, walkways, and driveways, due to their high resistance to weather and wear.",
+    )
+
+
+class GlassTileRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Glass Tiles.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    regular: bool | None = pyd.Field(
+        default=None,
+        description="Glass tile that is typically square or rectangular in shape, and used for a variety of decorative applications, such as kitchen backsplashes, shower walls, and accent borders.",
+    )
+    glass_mosaic: bool | None = pyd.Field(
+        default=None,
+        description="A small, decorative glass tile made in a variety of shapes and colors, used for intricate designs and patterns on walls, floors, and other surfaces.",
+    )
+    miniature_mosaic: bool | None = pyd.Field(
+        default=None,
+        description="Glass mosaic tile that is smaller in size than regular glass mosaic tile, often used for intricate details and designs in backsplashes, shower walls, and decorative accents.",
+    )
+    large_format: bool | None = pyd.Field(
+        default=None,
+        description="Glass tile that is larger in size than regular glass tile, often used to create a dramatic and modern effect in commercial and residential spaces.",
+    )
+
+
+class GypsumSupportsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Supports for suspended and furred gypsum wall and ceiling assemblies.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FlooringRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    General category - finishes for floors.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AccessFlooring: AccessFlooringRangeV1 | None = None
+    Carpet: CarpetRangeV1 | None = None
+    Laminate: LaminateRangeV1 | None = None
+    OtherFlooring: OtherFlooringRangeV1 | None = None
+    ResilientFlooring: ResilientFlooringRangeV1 | None = None
+    WallBase: WallBaseRangeV1 | None = None
+    WoodFlooring: WoodFlooringRangeV1 | None = None
+
+
+class CeilingPanelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Acoustical and other specialty ceiling panels.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fire_rating: list[CeilingPanelFireRating] | None = pyd.Field(default=None, description="")
+    core_material: list[CeilingPanelCoreMaterial] | None = pyd.Field(default=None, description="")
+    nrc: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Noise Reduction Coefficient (NRC) or Sound Absorbtion Average (SAA) per ASTM C423"
+    )
+    cac: RangeInt | None = pyd.Field(default=None, description="Ceiling Attenuation Class (CAC) per ASTM E1414")
+    AcousticalCeilings: AcousticalCeilingsRangeV1 | None = None
+
+
+class BackingAndUnderlayRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious, glass-mat faced gypsum, and fibered gypsum backing boards to support finish materials.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CementBoardRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Hard cementitious boards, typically used as a tile backer.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: list[CementBoardThickness] | None = pyd.Field(default=None, description="")
+
+
+class TilingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Decorative building materials that includes a variety of ceramic, porcelain, and glass tiles.
+
+    Used for covering and enhancing surfaces such as floors, walls, and countertops.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    flooring: bool | None = pyd.Field(default=None, description="Tiling intended for walking.")
+    wall_finish: bool | None = pyd.Field(
+        default=None,
+        description="A decorative tile designed for use on vertical surfaces such as walls or backsplashes.",
+    )
+    cladding: bool | None = pyd.Field(
+        default=None,
+        description="Tiling for exterior use, primarily used for the walls of buildings and structures, providing a protective and decorative layer that enhances the aesthetic appearance and weather resistance of the underlying structure.",
+    )
+    other: bool | None = pyd.Field(
+        default=None, description="Tiling used as countertops, ceilings, furnishings, hardscapes etc."
+    )
+    residential_only: bool | None = pyd.Field(
+        default=None,
+        description="All commercial tile can also be used in residential applications, but the opposite may not be true. This selection allows to filter out tiling that is not intended for commercial applications.",
+    )
+    reinforced: bool | None = pyd.Field(
+        default=None, description="Steel-reinforced ceramic tiles or tiles with other special reinforcing technology."
+    )
+    total_recycled_content: RangeRatioFloat | None = pyd.Field(
+        default=None,
+        description="Proportion of this product that is sourced from recycled content. Pre-consumer recycling is given a 50% weighting, 100% for post-consumer, by mass.",
+    )
+    post_consumer_recycled_content: RangeRatioFloat | None = pyd.Field(
+        default=None,
+        description="Proportion of this product that is sourced from post-consumer recycled content, by mass.",
+    )
+    CeramicTile: CeramicTileRangeV1 | None = None
+    GaugedTile: GaugedTileRangeV1 | None = None
+    GlassTile: GlassTileRangeV1 | None = None
+
+
+class DeckingBoardsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Decking boards provide the finished surface of a deck and support the weight of people and furniture.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    forest_practices_certifiers: list[OrgRef] | None = None
+    timber_species: list[SawnTimberSpecies] | None = pyd.Field(default=None, description="")
+    fabrication: list[AllFabrication] | None = pyd.Field(default=None, description="")
+    weather_exposed: bool | None = pyd.Field(default=None, description="")
+    fire_retardant: bool | None = pyd.Field(default=None, description="")
+    decay_resistant: bool | None = pyd.Field(default=None, description="")
+    material: list[DeckingBoardMaterial] | None = pyd.Field(default=None, description="")
+
+
+class GlassFiberReinforcedGypsumFabricationsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Gypsum with integrated glass fiber reinforcement, which may be fabricated in complex shapes or as a board.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class GypsumRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Gypsum board used for interior walls, ceilings, and similar applications.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    fire_rating: list[GypsumFireRating] | None = pyd.Field(default=None, description="")
+    thickness: list[GypsumThickness] | None = pyd.Field(default=None, description="")
+    facing: list[GypsumFacing] | None = pyd.Field(default=None, description="")
+    r_factor: str | None = pyd.Field(default=None, description="")
+    flame_spread_astm_e84: RangeInt | None = pyd.Field(default=None, description="")
+    smoke_production_astm_e84: RangeInt | None = pyd.Field(default=None, description="")
+    surface_abrasion_d4977: RangeInt | None = pyd.Field(default=None, description="")
+    indentation_d5420: RangeInt | None = pyd.Field(default=None, description="")
+    soft_body_impact_e695: RangeInt | None = pyd.Field(default=None, description="")
+    hard_body_impact_c1929: RangeInt | None = pyd.Field(default=None, description="")
+    mold_resistant: bool | None = pyd.Field(default=None, description="")
+    foil_backing: bool | None = pyd.Field(default=None, description="")
+    moisture_resistant: bool | None = pyd.Field(default=None, description="")
+    abuse_resistant: bool | None = pyd.Field(default=None, description="")
+    GypsumSupports: GypsumSupportsRangeV1 | None = None
+
+
+class MirrorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Mirrors.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PaintByMassRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Paintings and coatings by mass.
+
+    Expected declared unit for products is mass of ready to use product.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PaintByVolumeRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Paintings and coatings by volume.
+
+    Expecting declared unit for products is volume of ready to use product.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PaintByAreaRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Paintings and coatings by area.
+
+    Expected declared unit is area of host surface covered by the product.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PaintingAndCoatingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Paintings and coatings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    PaintByMass: PaintByMassRangeV1 | None = None
+    PaintByVolume: PaintByVolumeRangeV1 | None = None
+    PaintByArea: PaintByAreaRangeV1 | None = None
+
+
+class WallFinishesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Interior wall coverings including fabric, textile, wood, stone, and metal products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class PlasterRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Plaster, Stucco, & Render.
+
+    Used for the protective or decorative coating of walls and ceilings and for
+    moulding and casting decorative elements. These are typically gypsum-, lime-,
+    or cement-based. Products in this category refer to dry mix.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    composition: list[PlasterComposition] | None = pyd.Field(default=None, description="")
+    application_rate: RangeAmount | None = pyd.Field(
+        default=None, description="Typical or reference amount of material covering a unit of a host surface."
+    )
+
+
+class FinishesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    General category - finishes for interior ceilings, floors, walls.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    Flooring: FlooringRangeV1 | None = None
+    CeilingPanel: CeilingPanelRangeV1 | None = None
+    BackingAndUnderlay: BackingAndUnderlayRangeV1 | None = None
+    CementBoard: CementBoardRangeV1 | None = None
+    Tiling: TilingRangeV1 | None = None
+    DeckingBoards: DeckingBoardsRangeV1 | None = None
+    GlassFiberReinforcedGypsumFabrications: GlassFiberReinforcedGypsumFabricationsRangeV1 | None = None
+    Gypsum: GypsumRangeV1 | None = None
+    Mirrors: MirrorsRangeV1 | None = None
+    PaintingAndCoating: PaintingAndCoatingRangeV1 | None = None
+    WallFinishes: WallFinishesRangeV1 | None = None
+    Plaster: PlasterRangeV1 | None = None

--- a/src/openepd/model/specs/range/fire_and_smoke_protection.py
+++ b/src/openepd/model/specs/range/fire_and_smoke_protection.py
@@ -1,0 +1,108 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "IntumescentFireproofingRangeV1",
+    "SprayFireproofingRangeV1",
+    "AppliedFireproofingRangeV1",
+    "FirestoppingRangeV1",
+    "FireAndSmokeProtectionRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    IntumescentFireproofingMaterialType,
+    SprayFireproofingDensity,
+    SprayFireproofingMaterialType,
+)
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class IntumescentFireproofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fireproofing material applied to structural materials, which swells as a result of heat exposure.
+
+    As a result it increases in volume and decreasing in density.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    material_type: list[IntumescentFireproofingMaterialType] | None = pyd.Field(default=None, description="")
+
+
+class SprayFireproofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Spray fireproofing.
+
+    A passive fire protection system that reduces the rate of temperature increase in concrete or steel during a fire.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    material_type: list[SprayFireproofingMaterialType] | None = pyd.Field(default=None, description="")
+    density: list[SprayFireproofingDensity] | None = pyd.Field(default=None, description="")
+
+
+class AppliedFireproofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fireproofing material applied to structural materials.
+
+    Materials include: cement aggregate, cementitious, magnesium-oxychloride, intumescent, magnesium cement, mineral
+    fiber, and mineral fiber fireproofing products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    IntumescentFireproofing: IntumescentFireproofingRangeV1 | None = None
+    SprayFireproofing: SprayFireproofingRangeV1 | None = None
+
+
+class FirestoppingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Seals and protects openings and joints in fire rate assemblies.
+
+    Typically sealants, sprays, and caulks.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FireAndSmokeProtectionRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fire and smoke protection.
+
+    General category of materials whose function is to provide protection of materials, spaces, and occupants from
+    fire and smoke damage.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AppliedFireproofing: AppliedFireproofingRangeV1 | None = None
+    Firestopping: FirestoppingRangeV1 | None = None

--- a/src/openepd/model/specs/range/furnishings.py
+++ b/src/openepd/model/specs/range/furnishings.py
@@ -1,0 +1,137 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "DemountablePartitionTrackRangeV1",
+    "ChairsRangeV1",
+    "CountertopsRangeV1",
+    "DemountablePartitionsRangeV1",
+    "OtherFurnishingsRangeV1",
+    "StorageFurnitureRangeV1",
+    "TablesRangeV1",
+    "WorkSurfacesRangeV1",
+    "FurnishingsRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import CountertopMaterial
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class DemountablePartitionTrackRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Track for modular partitions.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ChairsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Chairs.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CountertopsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Raised, flat, and horizontal surfaces often used in kitchens, bathrooms, and workrooms.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    countertop_material: list[CountertopMaterial] | None = pyd.Field(default=None, description="")
+
+
+class DemountablePartitionsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Demountable partitions.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    DemountablePartitionTrack: DemountablePartitionTrackRangeV1 | None = None
+
+
+class OtherFurnishingsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other furnishings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class StorageFurnitureRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Storage Furniture.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class TablesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Tables.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WorkSurfacesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Work surfaces.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FurnishingsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Home and office furnishings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Chairs: ChairsRangeV1 | None = None
+    Countertops: CountertopsRangeV1 | None = None
+    DemountablePartitions: DemountablePartitionsRangeV1 | None = None
+    OtherFurnishings: OtherFurnishingsRangeV1 | None = None
+    StorageFurniture: StorageFurnitureRangeV1 | None = None
+    Tables: TablesRangeV1 | None = None
+    WorkSurfaces: WorkSurfacesRangeV1 | None = None

--- a/src/openepd/model/specs/range/grouting.py
+++ b/src/openepd/model/specs/range/grouting.py
@@ -1,0 +1,34 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("GroutingRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class GroutingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Grouting.
+
+    Water-cement-sand mixture for embedding rebar in masonry walls, connecting sections of precast concrete, and
+    filling joints and voids.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"

--- a/src/openepd/model/specs/range/manufacturing_inputs.py
+++ b/src/openepd/model/specs/range/manufacturing_inputs.py
@@ -1,0 +1,190 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "CementRangeV1",
+    "MasonryCementRangeV1",
+    "SupplementaryCementitiousMaterialsRangeV1",
+    "AccessFlooringPedestalsRangeV1",
+    "CarpetBackingRangeV1",
+    "CarpetFiberRangeV1",
+    "CementitiousMaterialsRangeV1",
+    "ConcreteAdmixturesRangeV1",
+    "TextilesRangeV1",
+    "ManufacturingInputsRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.concrete import Cementitious
+from openepd.model.specs.generated.enums import (
+    AdmixtureEffects,
+    CarpetYarnType,
+    CementAstmType,
+    CementC1157,
+    CementCsaA3001,
+    CementEn197_1,
+    CementScm,
+    MasonryCementAstmC91Type,
+    TextilesFabricType,
+)
+
+
+class CementRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cements.
+
+    Includes Portland and blended cements, that can serve as the primary binder in a concrete mix.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    cementitious: Cementitious | None = pyd.Field(default=None, description="")
+    white_cement: bool | None = pyd.Field(default=None, description="")
+    astm_type: list[CementAstmType] | None = pyd.Field(default=None, description="")
+    c1157: list[CementC1157] | None = pyd.Field(default=None, description="")
+    csa_a3001: list[CementCsaA3001] | None = pyd.Field(default=None, description="")
+    en197_1: list[CementEn197_1] | None = pyd.Field(default=None, description="")
+    oil_well_cement: bool | None = pyd.Field(default=None, description="")
+
+
+class MasonryCementRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    A cementitious product typically composed of Portland cement and hydrated lime.
+
+    Masonry cement is combined with sand to make mortar.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    astm_c91_type: list[MasonryCementAstmC91Type] | None = pyd.Field(default=None, description="")
+
+
+class SupplementaryCementitiousMaterialsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious materials that are not effective binders when used on their own.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    cement_scm: list[CementScm] | None = pyd.Field(default=None, description="")
+
+
+class AccessFlooringPedestalsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Part of an access floor system.
+
+    Pedestals are laid out on top of a floor slab and support access floor panels, creating a void space between the
+    floor slab and finish floor.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CarpetBackingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fabric backing holding a carpet together.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CarpetFiberRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fiber yarn used in the manufacture of carpet, typically nylon or wool.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    yarn_material: list[CarpetYarnType] | None = pyd.Field(default=None, description="")
+    yarn_recycled_content: RangeFloat | None = pyd.Field(default=None, description="")
+
+
+class CementitiousMaterialsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious materials performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Cement: CementRangeV1 | None = None
+    MasonryCement: MasonryCementRangeV1 | None = None
+    SupplementaryCementitiousMaterials: SupplementaryCementitiousMaterialsRangeV1 | None = None
+
+
+class ConcreteAdmixturesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Concrete admixtures.
+
+    Chemical additives that are added to fresh concrete immediately before or during mixing. Admixtures have distinct
+    functions and are categorized as: air-entraining, water-reducing, retarding, accelerating, and plasticizers
+    (i.e., superplasticizers).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    effects: list[AdmixtureEffects] | None = pyd.Field(default=None, description="")
+
+
+class TextilesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Textiles for use in manufacturing end products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabric_type: list[TextilesFabricType] | None = pyd.Field(default=None, description="")
+
+
+class ManufacturingInputsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Manufacturing inputs.
+
+    Broad category for collecting materials primarily used as manufacturing inputs, rather than directly used in
+    a construction.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AccessFlooringPedestals: AccessFlooringPedestalsRangeV1 | None = None
+    CarpetBacking: CarpetBackingRangeV1 | None = None
+    CarpetFiber: CarpetFiberRangeV1 | None = None
+    CementitiousMaterials: CementitiousMaterialsRangeV1 | None = None
+    ConcreteAdmixtures: ConcreteAdmixturesRangeV1 | None = None
+    Textiles: TextilesRangeV1 | None = None

--- a/src/openepd/model/specs/range/masonry.py
+++ b/src/openepd/model/specs/range/masonry.py
@@ -1,0 +1,87 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "GMURangeV1",
+    "AutoclavedAeratedConcreteRangeV1",
+    "BrickRangeV1",
+    "MasonryRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.validation.quantity import AmountRangePressureMpa
+
+
+class GMURangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Glass masonry unit.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AutoclavedAeratedConcreteRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    A lightweight, precast, foamed concrete masonry building material.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    strength_28d: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    thermal_conductivity: str | None = pyd.Field(default=None, description="")
+    white: bool | None = pyd.Field(default=None, description="")
+
+
+class BrickRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Solid masonry units made from clay or shale.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    building: bool | None = pyd.Field(default=None, description="")
+    facing: bool | None = pyd.Field(default=None, description="")
+    floor: bool | None = pyd.Field(default=None, description="")
+    pedestrian: bool | None = pyd.Field(default=None, description="")
+    paving: bool | None = pyd.Field(default=None, description="")
+    other: bool | None = pyd.Field(default=None, description="")
+    chemical_resistant: bool | None = pyd.Field(default=None, description="")
+    glazed: bool | None = pyd.Field(default=None, description="")
+    tiles: bool | None = pyd.Field(default=None, description="")
+
+
+class MasonryRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Structural and/or enclosure system based on individual rigid units stacked and bound together with mortar.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    white_cement: bool | None = pyd.Field(default=None, description="")
+    GMU: GMURangeV1 | None = None
+    AutoclavedAeratedConcrete: AutoclavedAeratedConcreteRangeV1 | None = None
+    Brick: BrickRangeV1 | None = None

--- a/src/openepd/model/specs/range/material_handling.py
+++ b/src/openepd/model/specs/range/material_handling.py
@@ -1,0 +1,50 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "ConveyorsRangeV1",
+    "MaterialHandlingRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class ConveyorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Machinery and tools designed to move materials within a facility, both manually and automatically.
+
+    This includes various types of conveyors such as belt, roller, and overhead conveyors.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MaterialHandlingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Material handling.
+
+    Equipment and supplies for moving, storing, administering, and protecting materials during the handling process.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Conveyors: ConveyorsRangeV1 | None = None

--- a/src/openepd/model/specs/range/mechanical.py
+++ b/src/openepd/model/specs/range/mechanical.py
@@ -1,0 +1,307 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "HvacVrfControlRangeV1",
+    "HvacVrfIndoorRangeV1",
+    "HvacVrfOutdoorRangeV1",
+    "HvacAirDiffusersRangeV1",
+    "HvacAirFiltersRangeV1",
+    "HvacAHUsRangeV1",
+    "HvacBoilersRangeV1",
+    "HvacChillersRangeV1",
+    "HvacFansRangeV1",
+    "HvacHeatPumpsRangeV1",
+    "HvacHeatExRangeV1",
+    "HvacPumpsRangeV1",
+    "HvacRTUsRangeV1",
+    "HvacVrfSystemsRangeV1",
+    "HvacDuctsRangeV1",
+    "MechanicalRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    AhuAirflowControl,
+    AhuZoneControl,
+    AirFiltersMediaType,
+    AirFiltersMervRating,
+    BoilerConfiguration,
+    BoilerEquipmentFuelType,
+    HeatPumpType,
+    HvacDuctMaterial,
+    HvacDuctShape,
+    HvacDuctType,
+    HvacHeatExchangersType,
+    MechanicalInstallation,
+    MechanicalRefrigerants,
+)
+from openepd.model.validation.quantity import (
+    AmountRangeAirflow,
+    AmountRangeAreaPerVolume,
+    AmountRangePower,
+    AmountRangePressureMpa,
+    AmountRangeVolume,
+)
+
+
+class HvacVrfControlRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Controller for adjusting airflow across the VRF system.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class HvacVrfIndoorRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Heating and cooling unit located on the inside of a building and supplies air to specific indoor zones.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    cooling_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    airflow_rate: AmountRangeAirflow | None = pyd.Field(default=None, description="")
+    air_volume: AmountRangeVolume | None = pyd.Field(default=None, description="")
+
+
+class HvacVrfOutdoorRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Heating and cooling unit that is on the outside of a building and distributes air to the indoor units.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    cooling_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    airflow_rate: AmountRangeAirflow | None = pyd.Field(default=None, description="")
+    air_volume: AmountRangeVolume | None = pyd.Field(default=None, description="")
+
+
+class HvacAirDiffusersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Room-side terminals for air distribution. This is different from Terminal Heating & Cooling Units.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class HvacAirFiltersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Device for filtering particles of dust, soot, etc., from the air passing through it.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    merv_rating: list[AirFiltersMervRating] | None = pyd.Field(default=None, description="")
+    media_type: list[AirFiltersMediaType] | None = pyd.Field(default=None, description="")
+
+
+class HvacAHUsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Device which provides healthy, dust free air to buildings with a good energy efficiency.
+
+    Usually a large metal box containing a blower, heating or cooling elements, filter racks or chambers, sound
+    attenuators, and dampers.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    installation: list[MechanicalInstallation] | None = pyd.Field(default=None, description="")
+    airflow_rate: AmountRangeAirflow | None = pyd.Field(default=None, description="")
+    air_volume: AmountRangeVolume | None = pyd.Field(default=None, description="")
+    cooling_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    airflow_control: list[AhuAirflowControl] | None = pyd.Field(default=None, description="")
+    zone_control: list[AhuZoneControl] | None = pyd.Field(default=None, description="")
+
+
+class HvacBoilersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Closed vessel for heating fluid.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    flow_rate: AmountRangeAreaPerVolume | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    configuration: list[BoilerConfiguration] | None = pyd.Field(default=None, description="")
+    fuel_type: list[BoilerEquipmentFuelType] | None = pyd.Field(default=None, description="")
+
+
+class HvacChillersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Machine that removes heat from a liquid coolant.
+
+    Uses a vapor-compression, adsorption refrigeration, or absorption refrigeration cycles. Incldues centrifugal,
+    water-cooled chillers, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    installation: list[MechanicalInstallation] | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    cooling_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    air_volume: AmountRangeVolume | None = pyd.Field(default=None, description="")
+    airflow_rate: AmountRangeAirflow | None = pyd.Field(default=None, description="")
+
+
+class HvacFansRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Apparatus with rotating blades that creates a current of air for cooling or ventilation.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class HvacHeatPumpsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Device that transfers thermal energy between spaces, including ground and air source heat pumps.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    cooling_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    heating_capacity: AmountRangePower | None = pyd.Field(default=None, description="")
+    air_volume: AmountRangeVolume | None = pyd.Field(default=None, description="")
+    airflow_rate: AmountRangeAirflow | None = pyd.Field(default=None, description="")
+    heat_pumps_type: list[HeatPumpType] | None = pyd.Field(default=None, description="")
+
+
+class HvacHeatExRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    HVAC heat exchangers.
+
+    Systems that with heat exchange cell which recovers and retains the heat that would otherwise be lost from the
+    extracted air.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    refrigerants: list[MechanicalRefrigerants] | None = pyd.Field(default=None, description="")
+    heat_exchangers_type: list[HvacHeatExchangersType] | None = pyd.Field(default=None, description="")
+
+
+class HvacPumpsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Pumps.
+
+    Mechanical device using suction or pressure to raise or move liquids, compress gases, or force air into
+    inflatable objects such as tires.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    flow_rate: AmountRangeAreaPerVolume | None = pyd.Field(default=None, description="")
+    pump_discharge_pressure: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    pump_horsepower: AmountRangePower | None = pyd.Field(default=None, description="")
+
+
+class HvacRTUsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    An air handler designed for outdoor use, typically on roofs.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class HvacVrfSystemsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Variable refrigerant flow (VRF).
+
+    Also known as variable refrigerant volume (VRV), is an HVAC technology that allows for varying degrees of cooling
+    in more specific areas.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    HvacVrfControl: HvacVrfControlRangeV1 | None = None
+    HvacVrfIndoor: HvacVrfIndoorRangeV1 | None = None
+    HvacVrfOutdoor: HvacVrfOutdoorRangeV1 | None = None
+
+
+class HvacDuctsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Ducts for HVAC systems performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    shape: list[HvacDuctShape] | None = pyd.Field(default=None, description="Hvac duct shape")
+    material: list[HvacDuctMaterial] | None = pyd.Field(default=None, description="Hvac duct material")
+    type: list[HvacDuctType] | None = pyd.Field(default=None, description="Hvac duct type")
+
+
+class MechanicalRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Mechanical performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    HvacAirDiffusers: HvacAirDiffusersRangeV1 | None = None
+    HvacAirFilters: HvacAirFiltersRangeV1 | None = None
+    HvacAHUs: HvacAHUsRangeV1 | None = None
+    HvacBoilers: HvacBoilersRangeV1 | None = None
+    HvacChillers: HvacChillersRangeV1 | None = None
+    HvacFans: HvacFansRangeV1 | None = None
+    HvacHeatPumps: HvacHeatPumpsRangeV1 | None = None
+    HvacHeatEx: HvacHeatExRangeV1 | None = None
+    HvacPumps: HvacPumpsRangeV1 | None = None
+    HvacRTUs: HvacRTUsRangeV1 | None = None
+    HvacVrfSystems: HvacVrfSystemsRangeV1 | None = None
+    HvacDucts: HvacDuctsRangeV1 | None = None

--- a/src/openepd/model/specs/range/mechanical_insulation.py
+++ b/src/openepd/model/specs/range/mechanical_insulation.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("MechanicalInsulationRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import InsulatingMaterial, InsulationIntendedApplication
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class MechanicalInsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Insulation products whose primary purpose is for mechanical systems rather than for building envelope.
+
+    Includes HVAC, plumbing, and acoustic insulations.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    r_value: RangeFloat | None = pyd.Field(default=None, description="")
+    material: list[InsulatingMaterial] | None = pyd.Field(default=None, description="")
+    intended_application: list[InsulationIntendedApplication] | None = pyd.Field(default=None, description="")
+    thickness_per_declared_unit: AmountRangeLengthMm | None = pyd.Field(default=None, description="")

--- a/src/openepd/model/specs/range/network_infrastructure.py
+++ b/src/openepd/model/specs/range/network_infrastructure.py
@@ -1,0 +1,208 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "PDURangeV1",
+    "CabinetsRacksAndEnclosuresRangeV1",
+    "DataCablingRangeV1",
+    "FloorBoxesAndAccessoriesRangeV1",
+    "NetworkingCableTraysRangeV1",
+    "NetworkingRacewaysRangeV1",
+    "CommunicationsConduitRangeV1",
+    "NetworkInfrastructureRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeInt
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    CableTraysMaterial,
+    CablingCategory,
+    CablingFireRating,
+    CablingJacketMaterial,
+    ConduitMaterial,
+    FloorBoxCoverMaterial,
+    FloorBoxFloorMaterial,
+    FloorBoxMaterial,
+    PduTechnology,
+    RacewaysMaterial,
+    RackType,
+)
+from openepd.model.validation.quantity import AmountRangeElectricalCurrent, AmountRangeLengthMm, AmountRangeMass
+
+
+class PDURangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Devices with multiple outputs designed to distribute power, often in a data center cabinet.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    amperage: AmountRangeElectricalCurrent | None = pyd.Field(default=None, description="")
+    outlet_level_metering: bool | None = pyd.Field(default=None, description="")
+    outlet_level_switching: bool | None = pyd.Field(default=None, description="")
+    pdu_technology: list[PduTechnology] | None = pyd.Field(default=None, description="")
+    pdu_outlets: RangeInt | None = pyd.Field(default=None, description="")
+
+
+class CabinetsRacksAndEnclosuresRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Physical support upon which network equipment is mounted. Includes cabinets, racks, frames, and enclosures.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    static_load: AmountRangeMass | None = pyd.Field(default=None, description="")
+    total_racking_units: RangeInt | None = pyd.Field(default=None, description="")
+    rack_type: list[RackType] | None = pyd.Field(default=None, description="")
+
+
+class DataCablingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Telecommunications cabling for buildings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    outdoor: bool | None = pyd.Field(default=None, description="")
+    cabling_category: list[CablingCategory] | None = pyd.Field(default=None, description="")
+    fire_rating: list[CablingFireRating] | None = pyd.Field(default=None, description="")
+    jacket_material: list[CablingJacketMaterial] | None = pyd.Field(default=None, description="")
+    shielded: bool | None = pyd.Field(default=None, description="Foil or similar electromagnetic shielding")
+    armored: bool | None = pyd.Field(default=None, description="Steel or similar physical armor jacket")
+    rohs: bool | None = pyd.Field(default=None, description="Certified ROHS Compliant")
+    reach: bool | None = pyd.Field(default=None, description="Certified REACH compliant")
+    zwtl: bool | None = pyd.Field(default=None, description="Certified ZWTL compliant")
+    connectorized: bool | None = pyd.Field(
+        default=None,
+        description="This cable is shipped as a specific length with integrated connectors. Impacts include the connectors for the specific cable length. Connectors add impact similar to 0.1-0.5 additional meters of cable",
+    )
+    thin_ethernet: bool | None = pyd.Field(
+        default=None,
+        description="At least part of this cable has a reduced outer diameter and thinner wires. Thin ethernet cables have handling advantages and tend to have a reduced impact, but also reduced channel length. See TIA 568.2-D Annex G.",
+    )
+
+
+class FloorBoxesAndAccessoriesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Electrical boxes that are installed in the floor.
+
+    Used to provide power and/or data connections to devices in a room or space.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    painted: bool | None = pyd.Field(default=None, description="")
+    fire_classified: bool | None = pyd.Field(
+        default=None, description="Includes hardware to maintain fire rating of the floor"
+    )
+    outdoor: bool | None = pyd.Field(default=None, description="Floor boxes installed in the ground")
+    raised: bool | None = pyd.Field(default=None, description="Used in raised or computer style flooring")
+    poke_through: bool | None = pyd.Field(
+        default=None, description="Used primarily in retrofit or renovation and will maintain fire rating of the floor"
+    )
+    cover: bool | None = pyd.Field(default=None, description="Floor box cover or lid for use with a separate floor box")
+    outlets: RangeInt | None = pyd.Field(
+        default=None,
+        description="Number of outlet ports from floor box, including power, data, video, and other connections",
+    )
+    material: list[FloorBoxMaterial] | None = pyd.Field(default=None, description="")
+    cover_material: list[FloorBoxCoverMaterial] | None = pyd.Field(default=None, description="")
+    floor_material: list[FloorBoxFloorMaterial] | None = pyd.Field(default=None, description="")
+
+
+class NetworkingCableTraysRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cable trays.
+
+    Mechanical support systems that provide a rigid structural system for cables used for communication and
+    power distribution.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    height: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    depth: AmountRangeLengthMm | None = pyd.Field(default=None, description="Depth of enclosure system")
+    static_load: AmountRangeMass | None = pyd.Field(default=None, description="Mass that the unit can hold")
+    ventilated: bool | None = pyd.Field(default=None, description="At least 40% of the tray base is open to air flow")
+    material: list[CableTraysMaterial] | None = pyd.Field(default=None, description="")
+
+
+class NetworkingRacewaysRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Surface-mounted systems along the perimeter of walls to route, conceal, and protect cables.
+
+    Often called trunking.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    width: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    depth: AmountRangeLengthMm | None = pyd.Field(default=None, description="Depth of enclosure system")
+    painted: bool | None = pyd.Field(default=None, description="")
+    divided: bool | None = pyd.Field(
+        default=None, description="Dual service raceway for high and low voltage data and power applications"
+    )
+    raceways_material: list[RacewaysMaterial] | None = pyd.Field(default=None, description="")
+
+
+class CommunicationsConduitRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Tubing used to protect and route communications wiring in a building or structure.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    nominal_diameter: AmountRangeLengthMm | None = None
+    outer_diameter: AmountRangeLengthMm | None = None
+    inner_diameter: AmountRangeLengthMm | None = None
+    wall_thickness: AmountRangeLengthMm | None = None
+    material: list[ConduitMaterial] | None = None
+
+
+class NetworkInfrastructureRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    General category for network infrastructure products for data centers and commercial and residential buildings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    PDU: PDURangeV1 | None = None
+    CabinetsRacksAndEnclosures: CabinetsRacksAndEnclosuresRangeV1 | None = None
+    DataCabling: DataCablingRangeV1 | None = None
+    FloorBoxesAndAccessories: FloorBoxesAndAccessoriesRangeV1 | None = None
+    NetworkingCableTrays: NetworkingCableTraysRangeV1 | None = None
+    NetworkingRaceways: NetworkingRacewaysRangeV1 | None = None
+    CommunicationsConduit: CommunicationsConduitRangeV1 | None = None

--- a/src/openepd/model/specs/range/openings.py
+++ b/src/openepd/model/specs/range/openings.py
@@ -1,0 +1,512 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "PanelDoorsRangeV1",
+    "PressureResistantDoorsRangeV1",
+    "SpecialFunctionDoorsRangeV1",
+    "SlidingGlassDoorsRangeV1",
+    "FenestrationAccessoriesRangeV1",
+    "FenestrationFramingRangeV1",
+    "FenestrationHardwareRangeV1",
+    "FlatGlassPanesRangeV1",
+    "ProcessedNonInsulatingGlassPanesRangeV1",
+    "GlazedDoorsRangeV1",
+    "UnitSkylightsRangeV1",
+    "WindowsRangeV1",
+    "IntegratedDoorsOpeningAssembliesRangeV1",
+    "MetalDoorAndFramesRangeV1",
+    "SpecialtyDoorsAndFramesRangeV1",
+    "WoodDoorsRangeV1",
+    "FenestrationPartsRangeV1",
+    "GlassPanesRangeV1",
+    "NAFSFenestrationRangeV1",
+    "InsulatingGlazingUnitsRangeV1",
+    "CurtainWallsRangeV1",
+    "DoorsAndFramesRangeV1",
+    "EntrancesRangeV1",
+    "GlazingRangeV1",
+    "StorefrontsRangeV1",
+    "TranslucentWallAndRoofAssembliesRangeV1",
+    "WindowWallAssembliesRangeV1",
+    "OpeningsRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeInt, RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    FlatGlassPanesThickness,
+    FrameMaterial,
+    HardwareFunction,
+    NAFSPerformanceGrade,
+    Spacer,
+    ThermalSeparation,
+)
+from openepd.model.specs.generated.openings import GlazingIntendedApplication, NAFSPerformanceClass
+from openepd.model.validation.quantity import AmountRangeLengthMm, AmountRangePressureMpa, AmountRangeSpeed
+
+
+class PanelDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Panel doors performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PressureResistantDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Pressure-Resistant Doors.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SpecialFunctionDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Special function doors.
+
+    Includes doors for e.g., cold storage, hangars, lightproof applications,
+    security, sound control, vaults, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    PanelDoors: PanelDoorsRangeV1 | None = None
+    PressureResistantDoors: PressureResistantDoorsRangeV1 | None = None
+
+
+class SlidingGlassDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Sliding glass doors performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FenestrationAccessoriesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fenestration accessories.
+
+    Gaskets, seals, fasteners, and other low-mass items which may be useful in calculating the impact of a
+    fenestration system.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FenestrationFramingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fenestration Framing.
+
+    Lineal elements ("sticks") for use in fenestration, including frames, sashes, and mullions.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thermal_separation: list[ThermalSeparation] | None = pyd.Field(default=None)
+    material: list[FrameMaterial] | None = pyd.Field(default=None)
+
+
+class FenestrationHardwareRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Locks, operation hardware, and other substantial items declared on a per-piece basis.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    function: list[HardwareFunction] | None = pyd.Field(default=None, description="")
+
+
+class FlatGlassPanesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Monolithic, uncoated flat glass panes that are not substantially processed.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: list[FlatGlassPanesThickness] | None = pyd.Field(default=None)
+
+
+class ProcessedNonInsulatingGlassPanesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Solid glass panes without internal gaps which have been heat-treated or otherwise substantially processed.
+
+    Includes:
+    1. Coatings including low-e and other coatings (see PCR)
+    2. laminating (fire-rated, glass clad polycarbonate, interlayers
+    3. Heat treated (heat strengthened, tempered, fire-rated)
+    4. Mechanically or chemically processed or fabricated
+    (edging, bending, etching, drilling, notching, cutting, polishing, etc)
+    5. combined products of processing in 1-5.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    low_emissivity: bool | None = None
+    electrochromic: bool | None = None
+    acid_etched: bool | None = None
+    tempered: bool | None = None
+    toughened: bool | None = None
+    laminated: bool | None = None
+    fire_resistant: bool | None = None
+    fire_protection: bool | None = None
+    pyrolytic_coated: bool | None = None
+    sputter_coat: bool | None = None
+    solar_heat_gain: RangeRatioFloat | None = None
+
+
+class GlazedDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Factory assembled door which is at least 50% glass by area.
+
+    Includes sliding patio doors and hinged doors.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class UnitSkylightsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Unit skylights performance specification.
+
+    A factory assembled fenestration unit for installation on the roof of a structure to provide interior
+    building spaces with natural daylight, warmth, and ventilation; generally not operable
+    by hand (cf. roof window). Includes frame(s) and possibly operating hardware.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WindowsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Windows including glazing and frame material.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class IntegratedDoorsOpeningAssembliesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Pre-installed unit that includes door, frame, and hardware.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MetalDoorAndFramesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Metal doors and frames.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SpecialtyDoorsAndFramesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Specialty doors and frames.
+
+    Includes e.g., access doors and panels, sliding glass doors, coiling doors, special function doors,
+    folding doors, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    SpecialFunctionDoors: SpecialFunctionDoorsRangeV1 | None = None
+    SlidingGlassDoors: SlidingGlassDoorsRangeV1 | None = None
+
+
+class WoodDoorsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wood doors performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FenestrationPartsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fenestration Parts.
+
+    Parts and assemblies for integration into building fenestration such as windows, curtain walls,
+    and storefronts.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    intended_application: GlazingIntendedApplication | None = pyd.Field(
+        default=None, description="Intended application."
+    )
+    FenestrationAccessories: FenestrationAccessoriesRangeV1 | None = None
+    FenestrationFraming: FenestrationFramingRangeV1 | None = None
+    FenestrationHardware: FenestrationHardwareRangeV1 | None = None
+
+
+class GlassPanesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Flat glass panes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    FlatGlassPanes: FlatGlassPanesRangeV1 | None = None
+    ProcessedNonInsulatingGlassPanes: ProcessedNonInsulatingGlassPanesRangeV1 | None = None
+
+
+class NAFSFenestrationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Factory assembled fenestration units compliant to the North American Fenestration Standard.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    low_emissivity: bool | None = None
+    electrochromic: bool | None = None
+    acid_etched: bool | None = None
+    tempered: bool | None = None
+    toughened: bool | None = None
+    laminated: bool | None = None
+    fire_resistant: bool | None = None
+    fire_protection: bool | None = None
+    pyrolytic_coated: bool | None = None
+    sputter_coat: bool | None = None
+    solar_heat_gain: RangeRatioFloat | None = None
+    hurricane_resistant: bool | None = pyd.Field(
+        default=None, description="The product has been designed to resist windborne debris."
+    )
+    assembly_u_factor: str | None = pyd.Field(
+        default=None, description="Weighted average conductance of heat across assembly (including frame)."
+    )
+    air_infiltration: AmountRangeSpeed | None = pyd.Field(
+        default=None, description="Air infiltration, measured at a certain level of Differential Pressure."
+    )
+    thermal_separation: list[ThermalSeparation] | None = pyd.Field(default=None)
+    dp_rating: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    glass_panes: RangeInt | None = pyd.Field(
+        default=None,
+        description="Number of panes, each separated by a cavity. A 3 pane unit has 2 cavities. example: 3",
+    )
+    performance_class: NAFSPerformanceClass | None = pyd.Field(
+        default=None, description="Performance class according to NAFS."
+    )
+    performance_grade: list[NAFSPerformanceGrade] | None = pyd.Field(
+        default=None,
+        description="NAFS Performance Grade. The NAFS Performance Grade is a number that represents the performance of the glazing product. The higher the number, the better the performance. The NAFS Performance Grade is calculated using the NAFS Performance Class, the NAFS Performance Index, and the NAFS Performance Factor. While it is expressed as pressure, there are specific values which are allowed. The values are listed in the enum.",
+    )
+    GlazedDoors: GlazedDoorsRangeV1 | None = None
+    UnitSkylights: UnitSkylightsRangeV1 | None = None
+    Windows: WindowsRangeV1 | None = None
+
+
+class InsulatingGlazingUnitsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Insulating glazing units performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    low_emissivity: bool | None = None
+    electrochromic: bool | None = None
+    acid_etched: bool | None = None
+    tempered: bool | None = None
+    toughened: bool | None = None
+    laminated: bool | None = None
+    fire_resistant: bool | None = None
+    fire_protection: bool | None = None
+    pyrolytic_coated: bool | None = None
+    sputter_coat: bool | None = None
+    solar_heat_gain: RangeRatioFloat | None = None
+    intended_application: GlazingIntendedApplication | None = pyd.Field(
+        default=None, description="Intended application for IGUs."
+    )
+    hurricane_resistant: bool | None = pyd.Field(default=None)
+    dp_rating: AmountRangePressureMpa | None = pyd.Field(
+        default=None, description="Maximum Differential Pressure, a measure of wind tolerance."
+    )
+    air_infiltration: AmountRangeSpeed | None = pyd.Field(
+        default=None, description="Air infiltration, measured at a certain level of Differential Pressure."
+    )
+    glass_panes: RangeInt | None = pyd.Field(
+        default=None,
+        description="Number of panes, each separated by a cavity. A 3 pane unit has 2 cavities. example: 3",
+    )
+    cog_u_factor: str | None = pyd.Field(default=None, description="Conductance of heat at center of glass.")
+    spacer: list[Spacer] | None = pyd.Field(default=None, description="Spacer material for Integrated Glass Unit.")
+
+
+class CurtainWallsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Curtain Walls.
+
+    Exterior skin of building where walls are non-structural and are outboard of the floor slabs,
+    often as system of aluminum framing with vision glass and opaque panels of glass, metal, or other
+    materials.
+
+    Can be 'unitized' (prefabricated off-site) or 'stick' (fabricated on site).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class DoorsAndFramesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Doors (the operable part) and frames (what holds the door proper).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    height: AmountRangeLengthMm | None = pyd.Field(default=None)
+    width: AmountRangeLengthMm | None = pyd.Field(default=None)
+    IntegratedDoorsOpeningAssemblies: IntegratedDoorsOpeningAssembliesRangeV1 | None = None
+    MetalDoorAndFrames: MetalDoorAndFramesRangeV1 | None = None
+    SpecialtyDoorsAndFrames: SpecialtyDoorsAndFramesRangeV1 | None = None
+    WoodDoors: WoodDoorsRangeV1 | None = None
+
+
+class EntrancesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Building entrances (distinct from the door proper).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class GlazingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Glazing performance specification.
+
+    Broad category of glass-based products, accessories, and assemblies ranging from
+    glass panes and framing to curtain walls.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    FenestrationParts: FenestrationPartsRangeV1 | None = None
+    GlassPanes: GlassPanesRangeV1 | None = None
+    NAFSFenestration: NAFSFenestrationRangeV1 | None = None
+    InsulatingGlazingUnits: InsulatingGlazingUnitsRangeV1 | None = None
+
+
+class StorefrontsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Storefronts.
+
+    Fabricated building facades commonly used in retail applications, typically one or two stories
+    tall and using metal framing and glass.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class TranslucentWallAndRoofAssembliesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Translucent wall and roof assemblies.
+
+    Includes structured polycarbonate panel and fiberglass sandwich panel assemblies.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WindowWallAssembliesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Window Wall Assemblies.
+
+    Exterior skin of building where walls are non-structural and sit between floor slabs, often as
+    system of aluminum framing with vision glass and opaque panels of glass, metal,
+    or other materials.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OpeningsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Openings performance specification.
+
+    General category that includes windows, storefronts, window walls, curtain walls,
+    doors, entrances, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None)
+    CurtainWalls: CurtainWallsRangeV1 | None = None
+    DoorsAndFrames: DoorsAndFramesRangeV1 | None = None
+    Entrances: EntrancesRangeV1 | None = None
+    Glazing: GlazingRangeV1 | None = None
+    Storefronts: StorefrontsRangeV1 | None = None
+    TranslucentWallAndRoofAssemblies: TranslucentWallAndRoofAssembliesRangeV1 | None = None
+    WindowWallAssemblies: WindowWallAssembliesRangeV1 | None = None

--- a/src/openepd/model/specs/range/other_electrical_equipment.py
+++ b/src/openepd/model/specs/range/other_electrical_equipment.py
@@ -1,0 +1,31 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("OtherElectricalEquipmentRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class OtherElectricalEquipmentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other Electrical Equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"

--- a/src/openepd/model/specs/range/other_materials.py
+++ b/src/openepd/model/specs/range/other_materials.py
@@ -1,0 +1,194 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "AuxiliariesRangeV1",
+    "CleaningProductsRangeV1",
+    "ClothingRangeV1",
+    "FoodBeverageRangeV1",
+    "TransportationInfrastructureRangeV1",
+    "UnsupportedRangeV1",
+    "CopperRangeV1",
+    "EarthworkRangeV1",
+    "ExteriorSunControlDevicesRangeV1",
+    "GypsumFinishingCompoundsRangeV1",
+    "ProfilesRangeV1",
+    "UnknownRangeV1",
+    "ZincRangeV1",
+    "OtherMaterialsRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+
+
+class AuxiliariesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Auxiliaries performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CleaningProductsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cleaning and disinfecting solutions.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ClothingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Clothing.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FoodBeverageRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Food Beverage and Tobacco Products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class TransportationInfrastructureRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    A broad category for unclassified materials focused on transportation infrastructure.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Auxiliaries: AuxiliariesRangeV1 | None = None
+
+
+class UnsupportedRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    A generic category for EPDs/Materials and categories that are explicitly not yet supported by EC3.
+
+    Assume that any data in this subcategory is unreliable.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    CleaningProducts: CleaningProductsRangeV1 | None = None
+    Clothing: ClothingRangeV1 | None = None
+    FoodBeverage: FoodBeverageRangeV1 | None = None
+
+
+class CopperRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Products made of copper.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class EarthworkRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Earthwork, including excavation, shoring, piles, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ExteriorSunControlDevicesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Sun control devices help to manage solar heat gain by redirecting sunlight.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class GypsumFinishingCompoundsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Plasters and the like for finishing Gypsum Sheet and Board.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ProfilesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Metal or polymer profiles used for producing or installing of Windows, Doors, Frames and Cladding.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class UnknownRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Materials with unknown category. Assume that any data in this subcategory is unreliable.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ZincRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Products made of zinc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OtherMaterialsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Broad category of materials not yet classified.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    TransportationInfrastructure: TransportationInfrastructureRangeV1 | None = None
+    Unsupported: UnsupportedRangeV1 | None = None
+    Copper: CopperRangeV1 | None = None
+    Earthwork: EarthworkRangeV1 | None = None
+    ExteriorSunControlDevices: ExteriorSunControlDevicesRangeV1 | None = None
+    GypsumFinishingCompounds: GypsumFinishingCompoundsRangeV1 | None = None
+    Profiles: ProfilesRangeV1 | None = None
+    Unknown: UnknownRangeV1 | None = None
+    Zinc: ZincRangeV1 | None = None

--- a/src/openepd/model/specs/range/plumbing.py
+++ b/src/openepd/model/specs/range/plumbing.py
@@ -1,0 +1,200 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "BathtubsRangeV1",
+    "FaucetsRangeV1",
+    "OtherPlumbingFixturesRangeV1",
+    "WaterClosetsRangeV1",
+    "FireProtectionPipingRangeV1",
+    "FireSprinklersRangeV1",
+    "StorageTanksRangeV1",
+    "WaterHeatersRangeV1",
+    "PlumbingFixturesRangeV1",
+    "FireSuppressionRangeV1",
+    "PipingRangeV1",
+    "PlumbingEquipmentRangeV1",
+    "PlumbingRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeAmount
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import FireProtectionPipingMaterial, PipingAnsiSchedule, PlumbingPipingMaterial
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class BathtubsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Bathtubs.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FaucetsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Faucets.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OtherPlumbingFixturesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Other plumbing fixtures.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WaterClosetsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Water Closets.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FireProtectionPipingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    System of pipes used to supply fire-suppression fluids to homes and/or businesses.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    piping_diameter: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    mass_per_unit_length: RangeAmount | None = pyd.Field(default=None, description="")
+    piping_ansi_schedule: list[PipingAnsiSchedule] | None = pyd.Field(default=None, description="")
+    fire_protection_piping_material: list[FireProtectionPipingMaterial] | None = pyd.Field(default=None, description="")
+
+
+class FireSprinklersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Fire sprinklers.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class StorageTanksRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Storage tanks.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WaterHeatersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Water heaters.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PlumbingFixturesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Residential and commercial water closets, urinals, lavatories, sinks, bathtubs, showers, faucets, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    Bathtubs: BathtubsRangeV1 | None = None
+    Faucets: FaucetsRangeV1 | None = None
+    OtherPlumbingFixtures: OtherPlumbingFixturesRangeV1 | None = None
+    WaterClosets: WaterClosetsRangeV1 | None = None
+
+
+class FireSuppressionRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Systems used to extinguish, control, or prevent fires.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    FireProtectionPiping: FireProtectionPipingRangeV1 | None = None
+    FireSprinklers: FireSprinklersRangeV1 | None = None
+
+
+class PipingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Piping.
+
+    System of pipes used to provide water and fuel, remove wastewater, allow venting of gases, or supply
+    fire-suppression fluids to homes, businesses, or other facilities.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    piping_diameter: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    mass_per_unit_length: RangeAmount | None = pyd.Field(default=None, description="")
+    piping_ansi_schedule: list[PipingAnsiSchedule] | None = pyd.Field(default=None, description="")
+    plumbing_piping_material: list[PlumbingPipingMaterial] | None = pyd.Field(default=None, description="")
+
+
+class PlumbingEquipmentRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Water softeners, filtration equipment, water heaters, and other plumbing equipment.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    StorageTanks: StorageTanksRangeV1 | None = None
+    WaterHeaters: WaterHeatersRangeV1 | None = None
+
+
+class PlumbingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Residential and commercial plumbing equipment and fixtures.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    PlumbingFixtures: PlumbingFixturesRangeV1 | None = None
+    FireSuppression: FireSuppressionRangeV1 | None = None
+    Piping: PipingRangeV1 | None = None
+    PlumbingEquipment: PlumbingEquipmentRangeV1 | None = None

--- a/src/openepd/model/specs/range/precast_concrete.py
+++ b/src/openepd/model/specs/range/precast_concrete.py
@@ -1,0 +1,115 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "ArchitecturalPrecastRangeV1",
+    "StructuralPrecastRangeV1",
+    "UtilityUndergroundPrecastRangeV1",
+    "CivilPrecastRangeV1",
+    "PrecastConcreteRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.precast_concrete import (
+    ArchitecturalPrecastElementType,
+    CivilPrecastElementType,
+    StructuralPrecastElementType,
+    UtilityPrecastElementType,
+)
+from openepd.model.validation.quantity import AmountRangePressureMpa
+
+
+class ArchitecturalPrecastRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Precast concrete cladding used for architectural purposes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    element_type: ArchitecturalPrecastElementType | None = pyd.Field(
+        default=None, description="Precast element type used for architectural applications."
+    )
+
+
+class StructuralPrecastRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Precast concrete used for structural purposes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    element_type: StructuralPrecastElementType | None = pyd.Field(
+        default=None, description="Precast element type used for structural applications."
+    )
+
+
+class UtilityUndergroundPrecastRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Precast concrete for utility vaults, manhole, drain inlets. Excludes piping.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    element_type: UtilityPrecastElementType | None = pyd.Field(
+        default=None, description="Precast element type used for utility underground applications."
+    )
+
+
+class CivilPrecastRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Precast concrete used for civil engineering applications including bridges, highways, and railroads.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    element_type: CivilPrecastElementType | None = pyd.Field(
+        default=None, description="Precast element type used as civil engineering components."
+    )
+
+
+class PrecastConcreteRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    General category for precast concrete components.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    lightweight: bool | None = pyd.Field(default=None, description="")
+    concrete_compressive_strength_28d: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+    insulated: bool | None = pyd.Field(default=None, description="")
+    gfrc: bool | None = pyd.Field(
+        default=None,
+        description="Glass Fiber Reinforced Concrete is fiber-reinforced concrete sometimes used in architectural panels",
+    )
+    steel_mass_percentage: RangeRatioFloat | None = pyd.Field(default=None, description="")
+    ArchitecturalPrecast: ArchitecturalPrecastRangeV1 | None = None
+    StructuralPrecast: StructuralPrecastRangeV1 | None = None
+    UtilityUndergroundPrecast: UtilityUndergroundPrecastRangeV1 | None = None
+    CivilPrecast: CivilPrecastRangeV1 | None = None

--- a/src/openepd/model/specs/range/sheathing.py
+++ b/src/openepd/model/specs/range/sheathing.py
@@ -1,0 +1,86 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "CementitiousSheathingBoardRangeV1",
+    "GypsumSheathingBoardRangeV1",
+    "SheathingRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeInt
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import GypsumFacing, GypsumFireRating, GypsumThickness
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class CementitiousSheathingBoardRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious sheathing board.
+
+    Cementitious non-gypsum board used for sheathing exteriors, shaft walls, and interior walls/ceilings requiring
+    moisture resistance.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    cement_board_thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class GypsumSheathingBoardRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cementitious sheathing board.
+
+    Gypsum board used for sheathing exteriors, shaft walls, and interior walls/ceilings requiring moisture resistance.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.1"
+
+    fire_rating: list[GypsumFireRating] | None = pyd.Field(default=None, description="")
+    thickness: list[GypsumThickness] | None = pyd.Field(default=None, description="")
+    facing: list[GypsumFacing] | None = pyd.Field(default=None, description="")
+    r_factor: str | None = pyd.Field(default=None, description="")
+    flame_spread_astm_e84: RangeInt | None = pyd.Field(default=None, description="")
+    smoke_production_astm_e84: RangeInt | None = pyd.Field(default=None, description="")
+    surface_abrasion_d4977: RangeInt | None = pyd.Field(default=None, description="")
+    indentation_d5420: RangeInt | None = pyd.Field(default=None, description="")
+    soft_body_impact_e695: RangeInt | None = pyd.Field(default=None, description="")
+    hard_body_impact_c1929: RangeInt | None = pyd.Field(default=None, description="")
+    mold_resistant: bool | None = pyd.Field(default=None, description="")
+    foil_backing: bool | None = pyd.Field(default=None, description="")
+    moisture_resistant: bool | None = pyd.Field(default=None, description="")
+    abuse_resistant: bool | None = pyd.Field(default=None, description="")
+
+
+class SheathingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Sheathing.
+
+    Boards or panels used in floor, wall and roof assemblies as a surface onto which other materials can be applied.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    CementitiousSheathingBoard: CementitiousSheathingBoardRangeV1 | None = None
+    GypsumSheathingBoard: GypsumSheathingBoardRangeV1 | None = None

--- a/src/openepd/model/specs/range/steel.py
+++ b/src/openepd/model/specs/range/steel.py
@@ -1,0 +1,332 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "ColdFormedFramingRangeV1",
+    "DeckingSteelRangeV1",
+    "SteelSuspensionAssemblyRangeV1",
+    "HollowSectionsRangeV1",
+    "HotRolledSectionsRangeV1",
+    "PlateSteelRangeV1",
+    "MetalRailingsRangeV1",
+    "MetalStairsRangeV1",
+    "MiscMetalFabricationRangeV1",
+    "OpenWebMembranesRangeV1",
+    "MBQSteelRangeV1",
+    "CoilSteelRangeV1",
+    "ColdFormedSteelRangeV1",
+    "StructuralSteelRangeV1",
+    "PrefabricatedSteelAssembliesRangeV1",
+    "PostTensioningSteelRangeV1",
+    "RebarSteelRangeV1",
+    "WireMeshSteelRangeV1",
+    "SteelRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat, RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import SteelComposition, SteelRebarGrade
+from openepd.model.specs.generated.steel import SteelMakingRoute
+from openepd.model.standard import Standard
+from openepd.model.validation.quantity import AmountRangeLengthMm, AmountRangePressureMpa
+
+
+class ColdFormedFramingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cold Formed Framing performance specification.
+
+    Cold formed steel elements such as studs and framing, typically made from coil or sheet steel and used
+    within walls and ceilings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class DeckingSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Corrugated Decking made from cold-formed sheet steel. Often filled with concrete.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SteelSuspensionAssemblyRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Steel suspension assemblies for suspended (e.g. acoustical) ceiling systems.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class HollowSectionsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Hollow cross section steel shape, typically referred to as hollow structural section (HSS).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabricated: bool | None = None
+
+
+class HotRolledSectionsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Hot rolled sections performance specification.
+
+    Steel shapes, such as angles, wide flange beams and I-beams, produced using a high temperature
+    mill process.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabricated: bool | None = None
+
+
+class PlateSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Plate Steels.
+
+    Flat hot-rolled steel, typically thicker than 'sheet', made by compressing multiple steel
+    layers together into one.
+
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabricated: bool | None = None
+
+
+class MetalRailingsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Metal Railings including pipe and tube railings.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MetalStairsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Metal stairs.
+
+    Includes: metal pan stairs, metal floor plate stairs, grating stairs, fire escapes,
+    ladders, and walkways/catwalks/ramps/platforms.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MiscMetalFabricationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Prefabricated steel assemblies not included in another category.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class OpenWebMembranesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Open web membranes performance specification.
+
+    Lightweight steel truss, typically made of parallel chords and a triangulated web system,
+    "proportioned to span between bearing points.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MBQSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Merchant Bar Quality (MBQ) steel.
+
+    Used as feedstock to steel construction products, but also includes rounds, angles, and light structural shapes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CoilSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Sheet or strip steel, sold in rolls.
+
+    Typically, coil steel is cold-formed into light gauge products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ColdFormedSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Cold Formed Steel Products.
+
+    All types of cold formed steel products. These products are made from hot-rolled steel coils and
+    sheets and are cold formed into products such as studs, decking, panels, and other accessories.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    ColdFormedFraming: ColdFormedFramingRangeV1 | None = None
+    DeckingSteel: DeckingSteelRangeV1 | None = None
+    SteelSuspensionAssembly: SteelSuspensionAssemblyRangeV1 | None = None
+
+
+class StructuralSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Structural Steel.
+
+    Hot rolled steel shapes, Hollow Sections, pipes, and similar hot-worked structural steels.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    modulus_of_elasticity: AmountRangePressureMpa | None = pyd.Field(
+        default=None, description="Modulus of Elasticity, https://en.wikipedia.org/wiki/Elastic_modulus "
+    )
+    thermal_expansion: str | None = pyd.Field(
+        default=None, description="Thermal Expansion, https://en.wikipedia.org/wiki/Thermal_expansion"
+    )
+    thermal_conductivity: str | None = pyd.Field(
+        default=None,
+        description="Thermal Conductivity, https://en.wikipedia.org/wiki/Thermal_conductivity_and_resistivity",
+    )
+    HollowSections: HollowSectionsRangeV1 | None = None
+    HotRolledSections: HotRolledSectionsRangeV1 | None = None
+    PlateSteel: PlateSteelRangeV1 | None = None
+
+
+class PrefabricatedSteelAssembliesRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Prefabricated assemblies made primarily of steel.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    MetalRailings: MetalRailingsRangeV1 | None = None
+    MetalStairs: MetalStairsRangeV1 | None = None
+    MiscMetalFabrication: MiscMetalFabricationRangeV1 | None = None
+    OpenWebMembranes: OpenWebMembranesRangeV1 | None = None
+
+
+class PostTensioningSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Steel tensioning cables or tendons for compression of prestressed concrete.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class RebarSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Reinforcing bar used together with concrete.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabricated: bool | None = None
+    grade: list[SteelRebarGrade] | None = pyd.Field(default=None)
+    diameter_min: AmountRangeLengthMm | None = pyd.Field(default=None, description="Minimal diameter")
+    bending_pin_max: RangeFloat | None = pyd.Field(default=None)
+    ts_ys_ratio_max: RangeFloat | None = pyd.Field(
+        default=None, description="Max ratio of ultimate tensile to yield tensile strength"
+    )
+    epoxy_coated: bool | None = pyd.Field(default=None)
+
+
+class WireMeshSteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Mild steel wire for reinforcement, connections, and meshes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabricated: bool | None = None
+
+
+class SteelRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Broad category for construction materials made from steel and its alloys.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    yield_tensile_str: AmountRangePressureMpa | None = pyd.Field(
+        default=None,
+        description="Yield Tensile strength (Mpa) per unit area. Yield strength is the point at which a material begins to permanently deform or change shape due to applied stress.",
+    )
+    bar_elongation: RangeFloat | None = pyd.Field(
+        default=None, description="Increase in length at break, in percent. Typically 10%-20%"
+    )
+    recycled_content: RangeRatioFloat | None = pyd.Field(default=None, description="")
+    post_consumer_recycled_content: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Should be a number between zero and the Recycled Content (steel_recycled_content)"
+    )
+    astm_marking: str | None = pyd.Field(default=None, description="The marking to be expected on the product.")
+    euro_marking: str | None = pyd.Field(default=None, description="The marking to be expected on the product.")
+    composition: list[SteelComposition] | None = pyd.Field(default=None, description="Basic chemical composition")
+    cold_finished: bool | None = pyd.Field(default=None)
+    galvanized: bool | None = pyd.Field(default=None)
+    stainless: bool | None = pyd.Field(default=None)
+    making_route: SteelMakingRoute | None = pyd.Field(default=None)
+    astm_standards: list[Standard] | None = pyd.Field(default=None, description="List of ASTM standards")
+    sae_standards: list[Standard] | None = pyd.Field(default=None, description="List of SAE standards")
+    en_standards: list[Standard] | None = pyd.Field(default=None, description="List of EN standards")
+    MBQSteel: MBQSteelRangeV1 | None = None
+    CoilSteel: CoilSteelRangeV1 | None = None
+    ColdFormedSteel: ColdFormedSteelRangeV1 | None = None
+    StructuralSteel: StructuralSteelRangeV1 | None = None
+    PrefabricatedSteelAssemblies: PrefabricatedSteelAssembliesRangeV1 | None = None
+    PostTensioningSteel: PostTensioningSteelRangeV1 | None = None
+    RebarSteel: RebarSteelRangeV1 | None = None
+    WireMeshSteel: WireMeshSteelRangeV1 | None = None

--- a/src/openepd/model/specs/range/thermal_moisture_protection.py
+++ b/src/openepd/model/specs/range/thermal_moisture_protection.py
@@ -1,0 +1,336 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "BituminousRoofingRangeV1",
+    "SinglePlyEPDMRangeV1",
+    "SinglePlyKEERangeV1",
+    "SinglePlyOtherRangeV1",
+    "SinglePlyPolyurethaneRangeV1",
+    "SinglePlyPVCRangeV1",
+    "SinglePlyTPORangeV1",
+    "BlanketInsulationRangeV1",
+    "BlownInsulationRangeV1",
+    "BoardInsulationRangeV1",
+    "FoamedInPlaceRangeV1",
+    "SprayedInsulationRangeV1",
+    "AirBarriersRangeV1",
+    "MembraneRoofingRangeV1",
+    "InsulationRangeV1",
+    "DampproofingAndWaterproofingRangeV1",
+    "FlashingAndSheetMetalRangeV1",
+    "JointProtectionRangeV1",
+    "RoofCoverBoardsRangeV1",
+    "SteepSlopeRoofingRangeV1",
+    "WeatherBarriersRangeV1",
+    "ThermalMoistureProtectionRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat, RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    FoamType,
+    InsulatingMaterial,
+    InsulationIntendedApplication,
+    MembraneRoofingReinforcement,
+    RoofCoverBoardsFacing,
+    RoofCoverBoardsMaterial,
+)
+from openepd.model.validation.quantity import AmountRangeLengthMm, AmountRangePressureMpa
+
+
+class BituminousRoofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Bituminous roofing.
+
+    Premanufactured membrane roofing sheets consisting of asphalt, reinforcing layers, and in some cases a surfacing.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyEPDMRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Ethylene propylene diene monomer (EPDM) rubber membrane.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyKEERangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Ketone Ethylene Ester (KEE) roof membranes.
+
+    Consist of PVC resin and KEE plasticizer, with KEE exceeding 50% of the polymer content by weight.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyOtherRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Single ply other performance specification.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyPolyurethaneRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Polyurethane liquid for flat roof waterproofing.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyPVCRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Polyvinyl chloride (PVC) thermoplastic membrane.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class SinglePlyTPORangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Thermoplastic Polyolefin (TPO) membrane.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class BlanketInsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Non-rigid insulation batts, blankets, and rolls.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class BlownInsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Loose-fill insulation for blow-in or closed cavity applications.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class BoardInsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Rigid insulation products including rigid foams, wood fiberboard insulation, and rigid mineral wool boards.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    compressive_strength: AmountRangePressureMpa | None = pyd.Field(default=None, description="")
+
+
+class FoamedInPlaceRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Open and closed cell spray foam insulation.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    foam_type: list[FoamType] | None = pyd.Field(default=None, description="")
+
+
+class SprayedInsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Spray-on insulation, such as spray-on cellulose.
+
+    Foaming sprays are categorized separately under foamed-in-place.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class AirBarriersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Air Infiltration Barrier.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MembraneRoofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Membrane roofing.
+
+    Built-up bituminous, modified bituminous, elastomeric, thermoplastic, fluid-applied, and hot-applied rubberized
+    asphalt membrane roofing.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    sri: RangeFloat | None = pyd.Field(default=None, description="")
+    total_recycled_content: RangeRatioFloat | None = pyd.Field(default=None, description="")
+    post_consumer_recycled_content: RangeRatioFloat | None = pyd.Field(default=None, description="")
+    reinforcement: list[MembraneRoofingReinforcement] | None = pyd.Field(default=None, description="")
+    felt_backing: bool | None = pyd.Field(default=None, description="")
+    nsf347: bool | None = pyd.Field(default=None, description="")
+    vantage_vinyl: bool | None = pyd.Field(default=None, description="")
+    BituminousRoofing: BituminousRoofingRangeV1 | None = None
+    SinglePlyEPDM: SinglePlyEPDMRangeV1 | None = None
+    SinglePlyKEE: SinglePlyKEERangeV1 | None = None
+    SinglePlyOther: SinglePlyOtherRangeV1 | None = None
+    SinglePlyPolyurethane: SinglePlyPolyurethaneRangeV1 | None = None
+    SinglePlyPVC: SinglePlyPVCRangeV1 | None = None
+    SinglePlyTPO: SinglePlyTPORangeV1 | None = None
+
+
+class InsulationRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Thermal insulation materials for use in construction.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    r_value: RangeFloat | None = pyd.Field(default=None, description="")
+    material: list[InsulatingMaterial] | None = pyd.Field(default=None, description="")
+    intended_application: list[InsulationIntendedApplication] | None = pyd.Field(default=None, description="")
+    thickness_per_declared_unit: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    BlanketInsulation: BlanketInsulationRangeV1 | None = None
+    BlownInsulation: BlownInsulationRangeV1 | None = None
+    BoardInsulation: BoardInsulationRangeV1 | None = None
+    FoamedInPlace: FoamedInPlaceRangeV1 | None = None
+    SprayedInsulation: SprayedInsulationRangeV1 | None = None
+
+
+class DampproofingAndWaterproofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Dampproofing and waterproofing.
+
+    Dampproofing, and built-up bituminous, sheet, fluid-applied, cementitious, reactive, and bentonite waterproofing.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class FlashingAndSheetMetalRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Exposed sheet metal items, typically for drainage.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class JointProtectionRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Preformed joint seals and sealants, expansion control joint cover assemblies.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class RoofCoverBoardsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Boards installed between the insulation and membrane layers on a roof system.
+
+    It provides additional durability, fire protection, thermal, and vapor performance to a roof system, especially
+    in low-slope, high foot traffic applications.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    material: list[RoofCoverBoardsMaterial] | None = pyd.Field(default=None, description="")
+    facing: list[RoofCoverBoardsFacing] | None = pyd.Field(default=None, description="")
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+
+
+class SteepSlopeRoofingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Roofing materials typically for slopes of 3:12 and greater.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WeatherBarriersRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Vapor retarders and sheet or membrane air barriers.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class ThermalMoistureProtectionRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Thermal moisture protection.
+
+    Broad category of materials whose function is to provide moisture and thermal protection between spaces (e.g.,
+    between the exterior and interior of a building).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    AirBarriers: AirBarriersRangeV1 | None = None
+    MembraneRoofing: MembraneRoofingRangeV1 | None = None
+    Insulation: InsulationRangeV1 | None = None
+    DampproofingAndWaterproofing: DampproofingAndWaterproofingRangeV1 | None = None
+    FlashingAndSheetMetal: FlashingAndSheetMetalRangeV1 | None = None
+    JointProtection: JointProtectionRangeV1 | None = None
+    RoofCoverBoards: RoofCoverBoardsRangeV1 | None = None
+    SteepSlopeRoofing: SteepSlopeRoofingRangeV1 | None = None
+    WeatherBarriers: WeatherBarriersRangeV1 | None = None

--- a/src/openepd/model/specs/range/utility_piping.py
+++ b/src/openepd/model/specs/range/utility_piping.py
@@ -1,0 +1,75 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "BuildingHeatingPipingRangeV1",
+    "BuriedPipingRangeV1",
+    "UtilityPipingRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeAmount
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import BuriedPipingType, PipingAnsiSchedule, UtilityPipingMaterial
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class BuildingHeatingPipingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Heating piping.
+
+    System of pipes used to supply heated fluids (liquids or steam) for purposes of controlling temperature inside a
+    home, business, or other building facility.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class BuriedPipingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    System of pipes used to provide or transport fluids (liquids and gases) underground.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    buried_piping_type: list[BuriedPipingType] | None = pyd.Field(default=None, description="")
+
+
+class UtilityPipingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Utility piping.
+
+    System of pipes used to convey fluids (liquids and gases) from one location to another. Piping can be metal,
+    plastic, concrete, fiberglass, or other materials.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    piping_diameter: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    mass_per_unit_length: RangeAmount | None = pyd.Field(default=None, description="")
+    piping_ansi_schedule: list[PipingAnsiSchedule] | None = pyd.Field(default=None, description="")
+    utility_piping_material: list[UtilityPipingMaterial] | None = pyd.Field(default=None, description="")
+    BuildingHeatingPiping: BuildingHeatingPipingRangeV1 | None = None
+    BuriedPiping: BuriedPipingRangeV1 | None = None

--- a/src/openepd/model/specs/range/wood.py
+++ b/src/openepd/model/specs/range/wood.py
@@ -1,0 +1,228 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = (
+    "WoodDeckingRangeV1",
+    "WoodFramingRangeV1",
+    "PrefabricatedWoodInsulatedPanelsRangeV1",
+    "PrefabricatedWoodTrussRangeV1",
+    "CompositeLumberRangeV1",
+    "DimensionLumberRangeV1",
+    "HeavyTimberRangeV1",
+    "MassTimberRangeV1",
+    "NonStructuralWoodRangeV1",
+    "PrefabricatedWoodRangeV1",
+    "SheathingPanelsRangeV1",
+    "UnfinishedWoodRangeV1",
+    "WoodRangeV1",
+)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.common import RangeFloat, RangeRatioFloat
+from openepd.model.org import OrgRef
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import (
+    AllFabrication,
+    AllTimberSpecies,
+    CompositeLumberFabrication,
+    EngineeredTimberSpecies,
+    MassTimberFabrication,
+    SawnTimberSpecies,
+    SheathingPanelsFabrication,
+)
+from openepd.model.validation.quantity import AmountRangeLengthMm
+
+
+class WoodDeckingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Dimensional boards for exterior decking.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WoodFramingRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Dimension lumber for light framing.
+
+    Includes solid and finger-jointed lumber. Standard shapes include 2x4, 2x6, and 2x8.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PrefabricatedWoodInsulatedPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Structural insulated panels (SIPs).
+
+    Consist of wood sheet layer(s) combined with (typically foam) insulation layer(s).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PrefabricatedWoodTrussRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Shop-fabricated wood truss.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class CompositeLumberRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Shop-fabricated structural Lumber.
+
+    Includes Laminated Strand Lumber (LSL), Parallel Strand Lumber (PSL), and Laminated Veneer Lumber (LVL).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabrication: list[CompositeLumberFabrication] | None = pyd.Field(default=None, description="")
+    timber_species: list[EngineeredTimberSpecies] | None = pyd.Field(default=None, description="")
+
+
+class DimensionLumberRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Dimension lumber for framing, decking, and other purposes.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    timber_species: list[SawnTimberSpecies] | None = pyd.Field(default=None, description="")
+    WoodDecking: WoodDeckingRangeV1 | None = None
+    WoodFraming: WoodFramingRangeV1 | None = None
+
+
+class HeavyTimberRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Large format, unfinished natural timber.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class MassTimberRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Engineered heavy timber products.
+
+    Includes glue laminated (glulam), cross-laminated timber (CLT), dowel laminated timber (DLT), and nail laminated
+    timber (NLT).
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabrication: list[MassTimberFabrication] | None = pyd.Field(default=None, description="")
+    timber_species: list[EngineeredTimberSpecies] | None = pyd.Field(default=None, description="")
+
+
+class NonStructuralWoodRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Non-structural interior and exterior wood products for trim, cabinets, countertops, etc.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class PrefabricatedWoodRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Prefabricated wood structural members made primarily from one or more types of wood.
+
+    Includes products made with metallic connectors, insulation, etc. Excludes products where the wood is merely
+    decorative.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    PrefabricatedWoodInsulatedPanels: PrefabricatedWoodInsulatedPanelsRangeV1 | None = None
+    PrefabricatedWoodTruss: PrefabricatedWoodTrussRangeV1 | None = None
+
+
+class SheathingPanelsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wood sheets used for structural sheathing, including plywood and Oriented Strand Board.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    fabrication: list[SheathingPanelsFabrication] | None = pyd.Field(default=None, description="")
+    wood_board_thickness: AmountRangeLengthMm | None = pyd.Field(default=None, description="")
+    timber_species: list[EngineeredTimberSpecies] | None = pyd.Field(default=None, description="")
+
+
+class UnfinishedWoodRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Raw logs and other unfinished wood products.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+
+class WoodRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Structural Wood Products used in construction.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    forest_practices_certifiers: list[OrgRef] | None = None
+    timber_species: list[AllTimberSpecies] | None = pyd.Field(default=None, description="Timber species")
+    fabrication: list[AllFabrication] | None = pyd.Field(default=None, description="Timber fabrication")
+    weather_exposed: bool | None = pyd.Field(default=None, description="Weather exposed")
+    fire_retardant: bool | None = pyd.Field(default=None, description="Fire retardant")
+    decay_resistant: bool | None = pyd.Field(default=None, description="Decay resistant")
+    fsc_certified: RangeRatioFloat | None = pyd.Field(
+        default=None, description="Forest Stewardship Council certified proportion"
+    )
+    fsc_certified_z: RangeFloat | None = pyd.Field(default=None, description="")
+    recycled_content: RangeRatioFloat | None = pyd.Field(default=None, description="Recycled content")
+    recycled_content_z: RangeFloat | None = pyd.Field(default=None, description="")
+    CompositeLumber: CompositeLumberRangeV1 | None = None
+    DimensionLumber: DimensionLumberRangeV1 | None = None
+    HeavyTimber: HeavyTimberRangeV1 | None = None
+    MassTimber: MassTimberRangeV1 | None = None
+    NonStructuralWood: NonStructuralWoodRangeV1 | None = None
+    PrefabricatedWood: PrefabricatedWoodRangeV1 | None = None
+    SheathingPanels: SheathingPanelsRangeV1 | None = None
+    UnfinishedWood: UnfinishedWoodRangeV1 | None = None

--- a/src/openepd/model/specs/range/wood_joists.py
+++ b/src/openepd/model/specs/range/wood_joists.py
@@ -1,0 +1,44 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+__all__ = ("WoodJoistsRangeV1",)
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+
+from openepd.compat.pydantic import pyd
+from openepd.model.org import OrgRef
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
+from openepd.model.specs.generated.enums import AllFabrication, AllTimberSpecies
+
+
+class WoodJoistsRangeV1(BaseOpenEpdHierarchicalSpec):
+    """
+    Wood joists.
+
+    Prefabricated I-shaped engineered wood structural members made primarily from one or more types of wood. Includes
+    products made with metallic webbing. Excludes products where the wood is merely decorative.
+
+    Range version.
+    """
+
+    _EXT_VERSION = "1.0"
+
+    forest_practices_certifiers: list[OrgRef] | None = None
+    timber_species: list[AllTimberSpecies] | None = pyd.Field(default=None, description="")
+    fabrication: list[AllFabrication] | None = pyd.Field(default=None, description="")
+    weather_exposed: bool | None = pyd.Field(default=None, description="")
+    fire_retardant: bool | None = pyd.Field(default=None, description="")
+    decay_resistant: bool | None = pyd.Field(default=None, description="")

--- a/src/openepd/model/validation/numbers.py
+++ b/src/openepd/model/validation/numbers.py
@@ -13,10 +13,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from typing import Annotated
 
-from openepd.compat.pydantic import pyd
 
-# todo when move to pydantic 2, check that validators are being enforced.
-RatioFloat = Annotated[float, pyd.Field(ge=0, le=1, example=0.5)]
-PositiveInt = Annotated[int, pyd.Field(ge=0, example=1)]
+# todo when move to pydantic 2, these should change to Annotated[float, ...]
+class RatioFloat(float):
+    """Float representing a ratio (0-1)."""
+
+    pass
+
+
+class PositiveInt(int):
+    """Greater than zero integer."""
+
+    pass

--- a/src/openepd/model/validation/quantity.py
+++ b/src/openepd/model/validation/quantity.py
@@ -325,7 +325,13 @@ class WithDimensionalityMixin(BaseOpenEpdSchema):
 class AmountRangeWithDimensionality(RangeAmount, WithDimensionalityMixin):
     """Mass amount, range."""
 
-    pass
+    class Config:
+        """Pydantic config."""
+
+        @staticmethod
+        def schema_extra(schema: dict[str, Any], model: type["AmountRangeWithDimensionality"]) -> None:
+            """Modify json schema."""
+            schema["example"] = {"min": 1.2, "max": 3.4, "unit": str(model.dimensionality_unit) or None}
 
 
 class WithMassKgMixin(WithDimensionalityMixin):

--- a/src/openepd/model/validation/quantity.py
+++ b/src/openepd/model/validation/quantity.py
@@ -17,12 +17,11 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 from openepd.compat.pydantic import pyd
-from openepd.model.common import Amount, OpenEPDUnit
+from openepd.model.base import BaseOpenEpdSchema
+from openepd.model.common import Amount, OpenEPDUnit, RangeAmount
 
 if TYPE_CHECKING:
-    from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
-
-    QuantityValidatorType = Callable[[type[BaseOpenEpdHierarchicalSpec], str], str]
+    QuantityValidatorType = Callable[[type, str], str]
 
 
 class QuantityValidator(ABC):
@@ -104,9 +103,20 @@ class ExternalValidationConfig:
 
 
 def validate_unit_factory(dimensionality: OpenEPDUnit | str) -> "QuantityValidatorType":
+    """Create validator for units (not quantities) to check for dimensionality."""
+
+    def validator(cls: type | None, value: str) -> str:
+        if ExternalValidationConfig.QUANTITY_VALIDATOR is not None:
+            ExternalValidationConfig.QUANTITY_VALIDATOR.validate_same_dimensionality(value, dimensionality)
+        return value
+
+    return validator
+
+
+def validate_quantity_unit_factory(dimensionality: OpenEPDUnit | str) -> "QuantityValidatorType":
     """Create validator for quantity field to check unit matching."""
 
-    def validator(cls: "type[BaseOpenEpdHierarchicalSpec]", value: str) -> str:
+    def validator(cls: type | None, value: str) -> str:
         if ExternalValidationConfig.QUANTITY_VALIDATOR is not None:
             ExternalValidationConfig.QUANTITY_VALIDATOR.validate_unit_correctness(value, dimensionality)
         return value
@@ -117,7 +127,7 @@ def validate_unit_factory(dimensionality: OpenEPDUnit | str) -> "QuantityValidat
 def validate_quantity_ge_factory(min_value: str) -> "QuantityValidatorType":
     """Create validator to check that quantity is greater than or equal to min_value."""
 
-    def validator(cls: "type[BaseOpenEpdHierarchicalSpec]", value: str) -> str:
+    def validator(cls: type | None, value: str) -> str:
         if ExternalValidationConfig.QUANTITY_VALIDATOR is not None:
             ExternalValidationConfig.QUANTITY_VALIDATOR.validate_quantity_greater_or_equal(value, min_value)
         return value
@@ -128,18 +138,7 @@ def validate_quantity_ge_factory(min_value: str) -> "QuantityValidatorType":
 def validate_quantity_le_factory(max_value: str) -> "QuantityValidatorType":
     """Create validator to check that quantity is less than or equal to max_value."""
 
-    def validator(cls: "type[BaseOpenEpdHierarchicalSpec]", value: str) -> str:
-        if ExternalValidationConfig.QUANTITY_VALIDATOR is not None:
-            ExternalValidationConfig.QUANTITY_VALIDATOR.validate_quantity_less_or_equal(value, max_value)
-        return value
-
-    return validator
-
-
-def validate_quantity_for_new_validator(max_value: str) -> Callable:
-    """Create validator to check that quantity is less than or equal to max_value."""
-
-    def validator(value: str) -> str:
+    def validator(cls: type | None, value: str) -> str:
         if ExternalValidationConfig.QUANTITY_VALIDATOR is not None:
             ExternalValidationConfig.QUANTITY_VALIDATOR.validate_quantity_less_or_equal(value, max_value)
         return value
@@ -149,38 +148,6 @@ def validate_quantity_for_new_validator(max_value: str) -> Callable:
 
 # for arbitrary non-standard quantity
 # todo these types should be replaced by Annotated[str, AfterValidator...] as we move completely to pydantic 2
-
-
-class AmountWithDimensionality(Amount, ABC):
-    """Class for dimensionality-validated amounts."""
-
-    dimensionality_unit: ClassVar[str | None] = None
-
-    # Unit for dimensionality to validate against, for example "kg"
-
-    @pyd.root_validator
-    def check_dimensionality_matches(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Check that this amount conforms to the same dimensionality as dimensionality_unit."""
-        if not cls.dimensionality_unit:
-            return values
-
-        from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec
-
-        str_repr = f"{values['qty']} {values['unit']}"
-        validate_unit_factory(cls.dimensionality_unit)(BaseOpenEpdHierarchicalSpec, str_repr)
-        return values
-
-
-class AmountMass(AmountWithDimensionality):
-    """Amount of mass, measured in kg, t, etc."""
-
-    dimensionality_unit = OpenEPDUnit.kg
-
-
-class AmountGWP(AmountWithDimensionality):
-    """Amount of Global Warming Potential, measured in kgCO2e."""
-
-    dimensionality_unit = OpenEPDUnit.kg_co2
 
 
 class QuantityStr(str):
@@ -196,7 +163,7 @@ class QuantityStr(str):
 
     @classmethod
     def __get_validators__(cls):
-        yield validate_unit_factory(cls.unit)
+        yield validate_quantity_unit_factory(cls.unit)
         yield validate_quantity_ge_factory(f"0 {cls.unit}")
 
     @classmethod
@@ -245,7 +212,7 @@ class LengthMmStr(QuantityStr):
 class LengthInchStr(QuantityStr):
     """Length (inch) quantity type."""
 
-    unit = OpenEPDUnit.m
+    unit = "inch"
 
     @classmethod
     def __modify_schema__(cls, field_schema):
@@ -336,3 +303,416 @@ class AreaPerVolumeStr(QuantityStr):
     """Area per unit of volume quantity type."""
 
     unit = "m2 / l"
+
+
+class WithDimensionalityMixin(BaseOpenEpdSchema):
+    """Class for dimensionality-validated amounts."""
+
+    dimensionality_unit: ClassVar[str | None] = None
+
+    # Unit for dimensionality to validate against, for example "kg"
+
+    @pyd.root_validator
+    def check_dimensionality_matches(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Check that this amount conforms to the same dimensionality as dimensionality_unit."""
+        if not cls.dimensionality_unit:
+            return values
+
+        validate_unit_factory(cls.dimensionality_unit)(BaseOpenEpdSchema, values.get("unit"))  # type:ignore [arg-type]
+        return values
+
+
+class AmountRangeWithDimensionality(RangeAmount, WithDimensionalityMixin):
+    """Mass amount, range."""
+
+    pass
+
+
+class WithMassKgMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = MassKgStr.unit
+
+
+class AmountMass(Amount, WithMassKgMixin):
+    """Amount of mass, measured in kg, t, etc."""
+
+    pass
+
+
+class AmountRangeMass(AmountRangeWithDimensionality, WithMassKgMixin):
+    """Range of masses."""
+
+    pass
+
+
+class WithGwpMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = GwpKgCo2eStr.unit
+
+
+class AmountGWP(Amount, WithGwpMixin):
+    """Amount of Global Warming Potential, measured in kgCO2e."""
+
+    pass
+
+
+class AmountRangeGWP(AmountRangeWithDimensionality, WithGwpMixin):
+    """Range of masses."""
+
+    pass
+
+
+class WithLengthMMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    pass
+
+
+class AmountRangeLengthM(AmountRangeWithDimensionality, WithLengthMMixin):
+    """Range of lengths (m)."""
+
+    pass
+
+
+class AmountLengthM(Amount, WithLengthMMixin):
+    """Length (m)."""
+
+    pass
+
+
+class WithLengthMmMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = LengthMmStr.unit
+
+
+class AmountLengthMm(Amount, WithLengthMMixin):
+    """Length (mm)."""
+
+    pass
+
+
+class AmountRangeLengthMm(AmountRangeWithDimensionality, WithLengthMmMixin):
+    """Range of lengths (mm)."""
+
+    pass
+
+
+class WithPressureMpaMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = PressureMPaStr.unit
+
+
+class AmountPressureMpa(Amount, WithPressureMpaMixin):
+    """Length (mm)."""
+
+    pass
+
+
+class AmountRangePressureMpa(AmountRangeWithDimensionality, WithPressureMpaMixin):
+    """Range of lengths (mm)."""
+
+    pass
+
+
+class WithAreaM2Mixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = AreaM2Str.unit
+
+
+class AmountAreaM2(Amount, WithAreaM2Mixin):
+    """Area (m2)."""
+
+    pass
+
+
+class AmountRangeAreaM2(AmountRangeWithDimensionality, WithAreaM2Mixin):
+    """Range of Area (m2)."""
+
+    pass
+
+
+class WithLengthInchStr(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = LengthInchStr.unit
+
+
+class AmountLengthInch(Amount, WithLengthInchStr):
+    """Length (inch)."""
+
+    pass
+
+
+class AmountRangeLengthInch(AmountRangeWithDimensionality, WithLengthInchStr):
+    """Range of Length (inch)."""
+
+    pass
+
+
+class WithTemperatureCMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = TemperatureCStr.unit
+
+
+class AmountTemperatureC(Amount, WithTemperatureCMixin):
+    """Temperature (degrees C)."""
+
+    pass
+
+
+class AmountRangeTemperatureC(AmountRangeWithDimensionality, WithTemperatureCMixin):
+    """Range of Temperature (degrees C)."""
+
+    pass
+
+
+class WithCapacityPerHourMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = CapacityPerHourStr.unit
+
+
+class AmountCapacityPerHour(Amount, WithCapacityPerHourMixin):
+    """Capacity per hour."""
+
+    pass
+
+
+class AmountRangeCapacityPerHour(AmountRangeWithDimensionality, WithCapacityPerHourMixin):
+    """Capacity per hour range."""
+
+    pass
+
+
+class WithRValueMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = RValueStr.unit
+
+
+class AmountRValue(Amount, WithRValueMixin):
+    """R-Value."""
+
+    pass
+
+
+class AmountRangeRValue(AmountRangeWithDimensionality, WithRValueMixin):
+    """R-Value range."""
+
+    pass
+
+
+class WithSpeedMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = SpeedStr.unit
+
+
+class AmountSpeed(Amount, WithSpeedMixin):
+    """Speed."""
+
+    pass
+
+
+class AmountRangeSpeed(AmountRangeWithDimensionality, WithSpeedMixin):
+    """Speed range."""
+
+    pass
+
+
+class WithColorTemperatureMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = ColorTemperatureStr.unit
+
+
+class AmountColorTemperature(Amount, WithColorTemperatureMixin):
+    """Color temperature."""
+
+    pass
+
+
+class AmountRangeColorTemperature(AmountRangeWithDimensionality, WithColorTemperatureMixin):
+    """Color temperature range."""
+
+    pass
+
+
+class WithLuminosityMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = LuminosityStr.unit
+
+
+class AmountLuminosity(Amount, WithLuminosityMixin):
+    """Luminosity."""
+
+    pass
+
+
+class AmountRangeLuminosity(AmountRangeWithDimensionality, WithLuminosityMixin):
+    """Luminosity range."""
+
+    pass
+
+
+class WithPowerMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = PowerStr.unit
+
+
+class AmountPower(Amount, WithPowerMixin):
+    """Power."""
+
+    pass
+
+
+class AmountRangePower(AmountRangeWithDimensionality, WithPowerMixin):
+    """Power range."""
+
+    pass
+
+
+class WithElectricalCurrentMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = ElectricalCurrentStr.unit
+
+
+class AmountElectricalCurrent(Amount, WithElectricalCurrentMixin):
+    """Current."""
+
+    pass
+
+
+class AmountRangeElectricalCurrent(AmountRangeWithDimensionality, WithElectricalCurrentMixin):
+    """Current range."""
+
+    pass
+
+
+class WithVolumeMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = VolumeStr.unit
+
+
+class AmountVolume(Amount, WithVolumeMixin):
+    """Volume."""
+
+    pass
+
+
+class AmountRangeVolume(AmountRangeWithDimensionality, WithVolumeMixin):
+    """Volume range."""
+
+    pass
+
+
+class WithAirflowMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = AirflowStr.unit
+
+
+class AmountAirflow(Amount, WithAirflowMixin):
+    """Airflow."""
+
+    pass
+
+
+class AmountRangeAirflow(AmountRangeWithDimensionality, WithAirflowMixin):
+    """Airflow range."""
+
+    pass
+
+
+class WithFlowRateMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = FlowRateStr.unit
+
+
+class AmountFlowRate(Amount, WithFlowRateMixin):
+    """Flow Rate."""
+
+    pass
+
+
+class AmountRangeFlowRate(AmountRangeWithDimensionality, WithFlowRateMixin):
+    """Flow Rate range."""
+
+    pass
+
+
+class WithMassPerLengthMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = MassPerLengthStr.unit
+
+
+class AmountMassPerLength(Amount, WithFlowRateMixin):
+    """Mass per length."""
+
+    pass
+
+
+class AmountRangeMassPerLength(AmountRangeWithDimensionality, WithFlowRateMixin):
+    """Mass per length range."""
+
+    pass
+
+
+class WithAreaPerVolumeMixin(WithDimensionalityMixin):
+    """Unit validation mixin."""
+
+    dimensionality_unit = AreaPerVolumeStr.unit
+
+
+class AmountAreaPerVolume(Amount, WithFlowRateMixin):
+    """Area per volume."""
+
+    pass
+
+
+class AmountRangeAreaPerVolume(AmountRangeWithDimensionality, WithFlowRateMixin):
+    """Area per volume range."""
+
+    pass
+
+
+# known range amounts
+SUPPORTED_RANGE_TYPES: tuple[type[AmountRangeWithDimensionality], ...] = (
+    AmountRangeMass,
+    AmountRangeGWP,
+    AmountRangeLengthM,
+    AmountRangeLengthMm,
+    AmountRangePressureMpa,
+    AmountRangeAreaM2,
+    AmountRangeLengthInch,
+    AmountRangeTemperatureC,
+    AmountRangeCapacityPerHour,
+    AmountRangeRValue,
+    AmountRangeSpeed,
+    AmountRangeColorTemperature,
+    AmountRangeLuminosity,
+    AmountRangePower,
+    AmountRangeElectricalCurrent,
+    AmountRangeVolume,
+    AmountRangeAirflow,
+    AmountRangeFlowRate,
+    AmountRangeMassPerLength,
+    AmountRangeAreaPerVolume,
+)
+
+# known range amount mapping by unit
+SUPPORTED_RANGES_BY_UNIT: dict[str, type[AmountRangeWithDimensionality]] = {
+    str(t.dimensionality_unit): t for t in SUPPORTED_RANGE_TYPES
+}

--- a/src/openepd/model/validation/quantity.py
+++ b/src/openepd/model/validation/quantity.py
@@ -163,8 +163,10 @@ class QuantityStr(str):
 
     @classmethod
     def __get_validators__(cls):
-        yield validate_quantity_unit_factory(cls.unit)
-        yield validate_quantity_ge_factory(f"0 {cls.unit}")
+        unit = getattr(cls, "unit", None)
+        if unit:
+            yield validate_quantity_unit_factory(cls.unit)
+            yield validate_quantity_ge_factory(f"0 {cls.unit}")
 
     @classmethod
     def __modify_schema__(cls, field_schema):

--- a/tools/openepd/codegen/generate_range_spec_models.py
+++ b/tools/openepd/codegen/generate_range_spec_models.py
@@ -1,0 +1,270 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import ast
+from collections import ChainMap, defaultdict
+from enum import Enum
+import importlib
+import inspect
+import os
+import pkgutil
+import re
+from types import GenericAlias, NoneType, UnionType
+import typing
+from typing import _GenericAlias
+
+import click
+import jinja2
+
+from openepd.model.common import RangeAmount, RangeFloat, RangeInt, RangeRatioFloat
+from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec, CodegenSpec
+from openepd.model.validation.numbers import RatioFloat
+from openepd.model.validation.quantity import SUPPORTED_RANGES_BY_UNIT, QuantityStr
+
+skip_fields = ("ext", "ext_version")
+skip_classes = ("BaseOpenEpdHierarchicalSpec",)
+skip_import_prefixes = (
+    "openepd.model.specs.generated",
+    "openepd.model.specs.generated.enums",
+    "openepd.model.validation.quantity",
+    "openepd.model.specs.base",
+    "openepd.model.base",
+    "openepd.model.common",
+    "openepd.validation.numbers",
+)
+
+
+def __range_spec_class_name_from_spec_name(spec_name: str) -> str:
+    class_name_match = re.match(r"^(\w+)(V\d+)$", spec_name)
+    if not class_name_match:
+        # case for special objects like top-level Specs which does not have a versioning scheme
+        return f"{spec_name}Range"
+    return f"{class_name_match.group(1)}Range{class_name_match.group(2)}"
+
+
+def filter__format_multiline_comment(v: str | None) -> str:
+    if v is None:
+        return ""
+    if not v.startswith("\n"):
+        return f"\n    {v}\n"
+    return v
+
+
+def __all_annotations(cls) -> ChainMap:
+    """Returns a dictionary-like ChainMap that includes annotations for all
+    attributes defined in cls or inherited from superclasses."""
+    return ChainMap(*(c.__annotations__ for c in cls.__mro__ if "__annotations__" in c.__dict__))
+
+
+def __get_absolute_import_path(cls: type | GenericAlias, import_collector: dict[str, set[str]]) -> str:
+    module_name = cls.__module__
+    module = importlib.import_module(module_name)
+    import_collector[module.__name__].add(cls.__name__)
+
+    if isinstance(cls, _GenericAlias):
+        return str(cls).split(".")[-1]
+
+    return cls.__name__
+
+
+def __quantity_str_type_to_range_type(t: type[QuantityStr]) -> type[RangeAmount]:
+    """Get the range type corresponding to a given unit."""
+    return SUPPORTED_RANGES_BY_UNIT.get(str(t.unit), RangeAmount)
+
+
+def __resolve_field_type(cls: type, field_name: str, import_collector: dict[str, set[str]]) -> str:
+    type_from_hints = typing.get_type_hints(cls)[field_name]
+    type_from_annotations = __all_annotations(cls)[field_name]
+
+    # shorthand - if overridden from the above
+    if typing.get_origin(type_from_annotations) is typing.Annotated:
+        type_parameters = typing.get_args(type_from_annotations)[1:]
+        for p in type_parameters:
+            if isinstance(p, CodegenSpec):
+                override_type = p.override_type
+                return f"{__get_absolute_import_path(override_type, import_collector)} | None"
+
+    # special matching required for Optional[] cases
+    if typing.get_origin(type_from_hints) in (UnionType, typing.Union) and type(None) in typing.get_args(
+        type_from_hints
+    ):
+        # in spec, everything should be nullable, so we strip the 'nullability' part of the union
+        union_members = [a for a in typing.get_args(type_from_hints) if a is not NoneType]
+
+        if len(union_members) != 1:
+            print(f"Unexpected union type, passing as is {type_from_hints}")
+            return str(type_from_hints)
+
+        # unpack generics
+        maybe_generic = union_members[0]
+        if isinstance(maybe_generic, GenericAlias):
+            real_type = typing.get_origin(maybe_generic)
+        else:
+            real_type = maybe_generic
+
+        match real_type:
+            case type() as t if issubclass(t, BaseOpenEpdHierarchicalSpec):
+                range_spec_class_name = __range_spec_class_name_from_spec_name(t.__name__)
+                if cls.__module__ != t.__module__:
+                    # foreign spec, import required
+                    relative_module_last = t.__module__.split(".")[-1]
+                    import_collector[f".{relative_module_last}"].add(range_spec_class_name)
+                return f"{range_spec_class_name} | None"
+            case type() as t if issubclass(t, RatioFloat):
+                return f"{__get_absolute_import_path(RangeRatioFloat, import_collector)} | None"
+            case type() as t if issubclass(t, float):
+                return f"{__get_absolute_import_path(RangeFloat, import_collector)} | None"
+            case type() as t if issubclass(t, bool):
+                return "bool | None"
+            case type() as t if issubclass(t, int):
+                return f"{__get_absolute_import_path(RangeInt, import_collector)} | None"
+            case type() as t if issubclass(t, QuantityStr):
+                return f"{__get_absolute_import_path(__quantity_str_type_to_range_type(t), import_collector)} | None"
+            case type() as t if issubclass(t, Enum):
+                return f"list[{__get_absolute_import_path(t, import_collector)}] | None"
+            case type() as t if issubclass(t, str):
+                return "str | None"
+            case type() as t if issubclass(t, list):
+                list_typing_args = typing.get_args(maybe_generic)
+                if not list_typing_args:
+                    return "list | None"
+                return f"list[{__get_absolute_import_path(list_typing_args[0], import_collector)}] | None"
+            case _:
+                return f"{__get_absolute_import_path(maybe_generic, import_collector)} | None"
+
+    return type_from_hints
+
+
+@click.command
+@click.argument("specs_source_package")
+@click.argument("output_folder")
+def generate_range_spec_models(specs_source_package: str, output_folder=None) -> None:
+    """
+    Generate material extension models (specs) for GenericEstimates and IndustryEPDs.
+
+    EPDs have material specifications attached. For EPDs themselves,these specifications often contain singular value -
+    for example, strength_28d=4000psi, fabrication=CLT etc. Generic and average datasets however are based on a range
+    of products or some market segment. To match these datasets, ranges are requried in some case, e.g. strength_28d =
+    4000 to 5000 psi.
+
+    Not all the properties of normal EPD are converted to ranges however, for example b1_recarbonation for CMU is never
+    a range.
+
+    This script generates the range spec models from normal spec models using rules and the code generation specifications
+    embedded into spec typings which handle special cases and exceptions.
+
+    Rules:
+    1. Quantity -> Range of Quantities
+    2. Enum value -> list of Enum values.
+    3. Float -> range of Floats.
+
+    We are accessing the source module (norma performance parameter spec) via 2 interfaces at the same time:
+    1. AST - gives us code-evel access, retains ordering, etc.
+    2. Inspect - gets the actual derived types.
+    """
+    package = importlib.import_module(specs_source_package)
+    try:
+        os.mkdir(output_folder)
+    except FileExistsError:
+        ...
+
+    for importer, module_name, ispkg in [*pkgutil.iter_modules(package.__path__), (None, "__init__", False)]:
+        if ispkg:
+            continue
+
+        # module which might contain specs
+        module = importlib.import_module(f"{specs_source_package}.{module_name}")
+
+        spec_classes = {}
+        for name, obj in inspect.getmembers(module):
+            if inspect.isclass(obj) and issubclass(obj, BaseOpenEpdHierarchicalSpec):
+                spec_classes[name] = obj
+
+        # no spec classes found; skip to next
+        if not spec_classes:
+            continue
+
+        # Parse the module's source code into an AST
+        with open(module.__file__, "r") as f:
+            tree = ast.parse(f.read())
+
+        #  module -> [symbol1, ...] structure. Results in from module import symobol1, ...
+        #  If no symbols, direct import will be used (import xxx)
+        import_collector: dict[str, set[str]] = defaultdict(set)
+        import_collector["openepd.model.specs.base"].add("BaseOpenEpdHierarchicalSpec")
+
+        # save the ordering of the class defs:
+        ast_class_defs: dict[str, dict[str, str]] = {}
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                field_declarations = {}
+                for n in node.body:
+                    if isinstance(n, ast.AnnAssign):
+                        field_init_expression = n.value
+                        if isinstance(field_init_expression, ast.Call):
+                            # assuming this is a rvalue of f = pyd.Field(default=..., example=...)
+                            field_init_expression.keywords = [
+                                kw for kw in field_init_expression.keywords if kw.arg not in ("example", "ge", "le")
+                            ]
+
+                        field_declarations[ast.unparse(n.target)] = ast.unparse(field_init_expression)
+                ast_class_defs[node.name] = field_declarations
+
+        include_pydantic_compat_import = False
+        class_definitions = []
+        for class_name, ast_class_def in ast_class_defs.items():
+            if class_name in skip_classes:
+                continue
+            if not (cls := spec_classes.get(class_name)):
+                continue
+
+            class_definition = {}
+            class_definitions.append(class_definition)
+
+            class_definition["classname"] = __range_spec_class_name_from_spec_name(class_name)
+            class_definition["class"] = cls
+            fields = []
+            class_definition["fields"] = fields
+            for field_name, field in cls.__fields__.items():
+                if field_name in skip_fields:
+                    continue
+
+                field_init = ast_class_def.get(field_name)
+                fields.append(
+                    {
+                        "name": field_name,
+                        "type": __resolve_field_type(cls, field_name, import_collector),
+                        "field_init": field_init,
+                    }
+                )
+
+                if field_init and "pyd" in field_init:
+                    import_collector["openepd.compat.pydantic"].add("pyd")
+
+        context = {
+            "imports": import_collector,
+            "include_pydantic_compat_import": include_pydantic_compat_import,
+            "range_specs": class_definitions,
+        }
+
+        environment = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.dirname(__file__)))
+        environment.filters["format_multiline_comment"] = filter__format_multiline_comment
+        template = environment.get_template("range_spec.py.tpl")
+        with open(os.path.join(output_folder, f"{module_name}.py"), mode="w") as f_out:
+            f_out.write(template.render(**context))
+
+
+if __name__ == "__main__":
+    generate_range_spec_models()

--- a/tools/openepd/codegen/range_spec.py.tpl
+++ b/tools/openepd/codegen/range_spec.py.tpl
@@ -1,0 +1,20 @@
+__all__ = {% for range_spec in range_specs %}"{{range_spec.classname}}", {%endfor%}
+
+# NB! This is a generated code. Do not edit it manually. Please see src/openepd/model/specs/README.md
+
+{% for module, symbols in imports.items() %}{% if symbols %}
+from {{module}} import {% for symbol in symbols%}{{symbol}}{{ ", " if not loop.last else "" }}{% endfor %}{% else %}
+import {{module}}{% endif %}{% endfor %}
+
+
+{% for range_spec in range_specs %}
+class {{range_spec.classname}}(BaseOpenEpdHierarchicalSpec):
+    """{{range_spec.class.__doc__ | format_multiline_comment}}
+    Range version.
+    """
+    _EXT_VERSION = "{{range_spec.class._EXT_VERSION}}"
+{% for field in range_spec.fields %}
+    {{field.name}}: {{field.type}} = {{field.field_init}}{% endfor %}
+
+
+{% endfor %}


### PR DESCRIPTION
- Range specs are generated from normal specs with make command
- Mostly the types generated follow the normal rules (quantity -> RangeAmount, enum - list of enums) but it is possible to override this with `Annotated[FieldType, CodegenSpec(override_type=AnotherFieldType)]`. 
- Cleaned up the validator factories (no interface is broken so not a breaking change)