### PR TITLE
fix: correct plant ID alias

### DIFF
--- a/src/openepd/model/org.py
+++ b/src/openepd/model/org.py
@@ -69,7 +69,6 @@ class Plant(WithAttachmentsMixin, WithAltIdsMixin, BaseOpenEpdSchema):
         description="Plus code (aka Open Location Code) of plant's location and "
         "owner's web domain joined with `.`(dot).",
         example="865P2W3V+3W.interface.com",
-        alias="pluscode",
         default=None,
     )
     owner: Org | None = pyd.Field(description="Organization that owns the plant", default=None)

--- a/src/openepd/model/tests/test_plant.py
+++ b/src/openepd/model/tests/test_plant.py
@@ -1,0 +1,32 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+from openepd.model.org import Plant
+
+
+class PlantTestCase(unittest.TestCase):
+    def test_plant_parse(self):
+        test_data = {
+            "id": "85644Q4R+3P.cemex.com",
+            "name": "Redlands RM (DUAL)",
+            "ref": "https://openepd.staging.epd.world/api/plants/85644Q4R+3P.cemex.com",
+            "pluscode": "85644Q4R+3P",
+            "address": "8203 Alabama St, Highland, CA 92346, USA",
+        }
+        p = Plant.parse_obj(test_data)
+
+        self.assertEqual(p.id, "85644Q4R+3P.cemex.com")


### PR DESCRIPTION
asana: [openEPD/CQDbot: Pydantic object for Plant missing pluscode, wrong id](https://app.asana.com/0/1203527467850668/1208226163370403/f)