### PR TITLE
feat: add exclusive group validator for exposure classes

### DIFF
--- a/src/openepd/model/common.py
+++ b/src/openepd/model/common.py
@@ -189,3 +189,17 @@ class RangeAmount(RangeFloat):
     """Structure representing a range of quantities."""
 
     unit: str | None = pyd.Field(default=None, description="Unit of the range.")
+
+
+class EnumGroupingAware:
+    """
+    Mixin for enums to support groups.
+
+    With the groups, enum can group its values into more than one groups, so that the validator higher in code can check
+    for mutual exclusivity, for example that only one value from the group is permitted at the same time.
+    """
+
+    @classmethod
+    def get_groupings(cls) -> list[list]:
+        """Return logical groupings of the values."""
+        return []

--- a/src/openepd/model/specs/generated/concrete.py
+++ b/src/openepd/model/specs/generated/concrete.py
@@ -19,6 +19,7 @@ from openepd.compat.pydantic import pyd
 from openepd.model.specs.base import BaseOpenEpdHierarchicalSpec, CodegenSpec
 from openepd.model.specs.concrete import Cementitious, ConcreteTypicalApplication
 from openepd.model.specs.generated.enums import AciExposureClass, CsaExposureClass, EnExposureClass
+from openepd.model.validation.enum import exclusive_groups_validator_factory
 from openepd.model.validation.numbers import RatioFloat
 from openepd.model.validation.quantity import (
     LengthInchStr,
@@ -172,3 +173,13 @@ class ConcreteV1(BaseOpenEpdHierarchicalSpec):
     OilPatch: OilPatchV1 | None = None
     ReadyMix: ReadyMixV1 | None = None
     Shotcrete: ShotcreteV1 | None = None
+
+    _aci_exposure_classes_exclusive_groups_validator = pyd.validator("aci_exposure_classes", allow_reuse=True)(
+        exclusive_groups_validator_factory(AciExposureClass)
+    )
+    _en_exposure_classes_exclusive_groups_validator = pyd.validator("en_exposure_classes", allow_reuse=True)(
+        exclusive_groups_validator_factory(EnExposureClass)
+    )
+    _csa_exposure_classes_exclusive_groups_validator = pyd.validator("csa_exposure_classes", allow_reuse=True)(
+        exclusive_groups_validator_factory(CsaExposureClass)
+    )

--- a/src/openepd/model/specs/generated/enums.py
+++ b/src/openepd/model/specs/generated/enums.py
@@ -15,6 +15,8 @@
 #
 from enum import StrEnum
 
+from openepd.model.common import EnumGroupingAware
+
 # Enums used
 
 
@@ -2182,7 +2184,7 @@ class FloorBoxFloorMaterial(StrEnum):
     OTHER = "Other"
 
 
-class AciExposureClass(StrEnum):
+class AciExposureClass(EnumGroupingAware, StrEnum):
     """
     American Concrete Institute concrete exposure classes.
 
@@ -2196,6 +2198,7 @@ class AciExposureClass(StrEnum):
       * `aci.S2` - Exposed to <10000 ppm of SO4 in water and <2% SO4 in soil
       * `aci.S3` - Exposed to >10000 ppm of SO4 in water or >2% SO4 in soil
 
+      * `aci.C0` - Concrete dry or protected from moisture.
       * `aci.C1` - Concrete in contact with moisture, but the external source of chloride does not reach it.
       * `aci.C2` - Concrete subjected to moisture and an external source of chlorides such as deicing chemicals,
                     salt, brackish water, seawater, or spray from these sources.
@@ -2212,14 +2215,25 @@ class AciExposureClass(StrEnum):
     S1 = "aci.S1"
     S2 = "aci.S2"
     S3 = "aci.S3"
+    C0 = "aci.C1"
     C1 = "aci.C1"
     C2 = "aci.C2"
     W0 = "aci.W0"
     W1 = "aci.W1"
     W2 = "aci.W2"
 
+    @classmethod
+    def get_groupings(cls) -> list[list]:
+        """Return logical groupings of the values."""
+        return [
+            [AciExposureClass.F0, AciExposureClass.F1, AciExposureClass.F2, AciExposureClass.F3],
+            [AciExposureClass.S0, AciExposureClass.S1, AciExposureClass.S2, AciExposureClass.S3],
+            [AciExposureClass.W0, AciExposureClass.W1],
+            [AciExposureClass.C0, AciExposureClass.C1, AciExposureClass.C2],
+        ]
 
-class CsaExposureClass(StrEnum):
+
+class CsaExposureClass(EnumGroupingAware, StrEnum):
     """
     Canadian Standard Association concrete exposure classes.
 
@@ -2286,8 +2300,20 @@ class CsaExposureClass(StrEnum):
     A_3 = "csa.A-3"
     A_4 = "csa.A-4"
 
+    @classmethod
+    def get_groupings(cls) -> list[list]:
+        """Return logical groupings of the values."""
+        return [
+            [CsaExposureClass.C_XL],
+            [CsaExposureClass.C_1, CsaExposureClass.C_2, CsaExposureClass.C_3, CsaExposureClass.C_4],
+            [CsaExposureClass.F_1, CsaExposureClass.F2],
+            [CsaExposureClass.N],
+            [CsaExposureClass.A_1, CsaExposureClass.A_2, CsaExposureClass.A_3, CsaExposureClass.A_4],
+            [CsaExposureClass.S_1, CsaExposureClass.S_2, CsaExposureClass.S_3],
+        ]
 
-class EnExposureClass(StrEnum):
+
+class EnExposureClass(EnumGroupingAware, StrEnum):
     """
     EN 206 Class (Europe).
 
@@ -2347,6 +2373,28 @@ class EnExposureClass(StrEnum):
     en206_XA1 = "en206.XA1"
     en206_XA2 = "en206.XA2"
     en206_XA3 = "en206.XA3"
+
+    @classmethod
+    def get_groupings(cls) -> list[list]:
+        """Return logical groupings of the values."""
+        return [
+            [EnExposureClass.en206_X0],
+            [
+                EnExposureClass.en206_XC1,
+                EnExposureClass.en206_XC2,
+                EnExposureClass.en206_XC3,
+                EnExposureClass.en206_XC4,
+            ],
+            [EnExposureClass.en206_XD1, EnExposureClass.en206_XD2, EnExposureClass.en206_XD3],
+            [EnExposureClass.en206_XS1, EnExposureClass.en206_XS2, EnExposureClass.en206_XS3],
+            [
+                EnExposureClass.en206_XF1,
+                EnExposureClass.en206_XF2,
+                EnExposureClass.en206_XF3,
+                EnExposureClass.en206_XF4,
+            ],
+            [EnExposureClass.en206_XA1, EnExposureClass.en206_XA2, EnExposureClass.en206_XA3],
+        ]
 
 
 class AggregateWeightClassification(StrEnum):

--- a/src/openepd/model/tests/test_spec_validation.py
+++ b/src/openepd/model/tests/test_spec_validation.py
@@ -1,0 +1,62 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+from openepd.compat.pydantic import pyd
+from openepd.model.specs import ConcreteV1
+from openepd.model.specs.generated.enums import AciExposureClass, CsaExposureClass, EnExposureClass
+
+
+class SpecValidationTestCase(unittest.TestCase):
+
+    def test_exclusive_list_validation(self) -> None:
+        ok_cases = (
+            {"aci_exposure_classes": []},
+            {"aci_exposure_classes": None},
+            {"aci_exposure_classes": [AciExposureClass.F0]},
+            {"aci_exposure_classes": [AciExposureClass.F0, AciExposureClass.W0, AciExposureClass.C2]},
+            {"csa_exposure_classes": [CsaExposureClass.C_XL, CsaExposureClass.C_1, CsaExposureClass.N]},
+            {"csa_exposure_classes": []},
+            {"csa_exposure_classes": None},
+            {"csa_exposure_classes": [CsaExposureClass.N]},
+            {
+                "en_exposure_classes": [
+                    EnExposureClass.en206_X0,
+                    EnExposureClass.en206_XC1,
+                    EnExposureClass.en206_XD1,
+                    EnExposureClass.en206_XS1,
+                    EnExposureClass.en206_XF1,
+                    EnExposureClass.en206_XA1,
+                ]
+            },
+            {"en_exposure_classes": []},
+            {"en_exposure_classes": None},
+            {"en_exposure_classes": [EnExposureClass.en206_XA1]},
+        )
+        for case in ok_cases:
+            ConcreteV1(**case)
+
+        not_ok_cases = (
+            {"aci_exposure_classes": [AciExposureClass.F0, AciExposureClass.F1]},
+            {"aci_exposure_classes": [AciExposureClass.S0, AciExposureClass.S1]},
+            {"csa_exposure_classes": [CsaExposureClass.C_XL, CsaExposureClass.C_1, CsaExposureClass.C_2]},
+            {"csa_exposure_classes": [CsaExposureClass.S_1, CsaExposureClass.S_2]},
+            {"en_exposure_classes": [EnExposureClass.en206_XC1, EnExposureClass.en206_XC2]},
+            {"en_exposure_classes": [EnExposureClass.en206_XD1, EnExposureClass.en206_XD2]},
+        )
+        for case in not_ok_cases:
+            with self.assertRaises(pyd.ValidationError):
+                ConcreteV1(**case)

--- a/src/openepd/model/validation/enum.py
+++ b/src/openepd/model/validation/enum.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2024 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from typing import Any, Callable
+
+from openepd.model.common import EnumGroupingAware
+
+
+def exclusive_groups_validator_factory(enum_type: type[EnumGroupingAware]) -> Callable[[type, Any], Any]:
+    """
+    Create an exclusive groups validator.
+
+    If we have a certain enum TheEnum, and a field of list[TheEnum], where list can contain only one value of each of
+    the groups, this validator should be used. For example, ACI exposure classes for concrete specify various
+    parameters such as water resistance, chemical resistance, etc., and the list of classes can have 0 or 1 from each
+    group.
+
+    :param enum_type:Enum type which supports groupings.
+    :return:value, or raises ValueError if not allowed combination is given.
+    """
+
+    def enum_exclusive_grouping_validator(cls, value: list | None) -> list | None:
+        for grouping in enum_type.get_groupings():
+            matching_from_group = [v for v in (value or []) if v in grouping]
+            if len(matching_from_group) > 1:
+                raise ValueError(f"Values {', '.join(matching_from_group)} are not allowed together.")
+
+        return value
+
+    return enum_exclusive_grouping_validator


### PR DESCRIPTION
For concretes, exposure classes are expressed as a list of enum values, for example `csa_exposure_class: list[CsaExposureClass]`. However, some values in a group are mutually exclusive, for example it should not be possible to supply both the `C1` and `C2` values at the same time as they describe resistance to chlorides and freezing.

asana: [openEPD exposure classes advanced validation](https://app.asana.com/0/1203527467850668/1208255682745232/f)