### PR TITLE
fix: make known scopes validate for same-unit using dimensionality check

### DIFF
--- a/src/openepd/model/lcia.py
+++ b/src/openepd/model/lcia.py
@@ -206,9 +206,17 @@ class ScopeSet(BaseOpenEpdSchema):
             if isinstance(v, Measurement):
                 all_units.add(v.unit)
 
-        # units should be the same across all measurements (textually)
-        if len(all_units) > 1:
-            raise ValueError("All scopes and measurements should be expressed in the same unit.")
+        if not cls.allowed_units:
+            # For unknown units - only units should be the same across all measurements (textually)
+            if len(all_units) > 1:
+                raise ValueError("All scopes and measurements should be expressed in the same unit.")
+        else:
+            # might be multiple variations of the same unit (kgCFC-11e, kgCFC11e)
+            if len(all_units) > 1 and ExternalValidationConfig.QUANTITY_VALIDATOR:
+                all_units_list = list(all_units)
+                first = all_units_list[0]
+                for unit in all_units_list[1:]:
+                    ExternalValidationConfig.QUANTITY_VALIDATOR.validate_same_dimensionality(first, unit)
 
         # can correctly validate unit
         if cls.allowed_units is not None and len(all_units) == 1 and ExternalValidationConfig.QUANTITY_VALIDATOR:

--- a/src/openepd/model/validation/quantity.py
+++ b/src/openepd/model/validation/quantity.py
@@ -33,7 +33,7 @@ class QuantityValidator(ABC):
     """
 
     @abstractmethod
-    def validate_same_dimensionality(self, unit: str | None, dimensionality_unit: str) -> None:
+    def validate_same_dimensionality(self, unit: str | None, dimensionality_unit: str | None) -> None:
         """
         Validate that a given unit ('kg') has the same dimesnionality as provided dimensionality_unit ('g').
 


### PR DESCRIPTION
Unknown scopes are still checked via textual unit validation (e.g. 'msec/m' would not work together with 'hour/km'). Known scopes will check dimensionalities are same (e.g. 'kgCFC11e' and 'kgCFC-11e' together are OK).

asana: [[Manage Data] 400 error falls on attempt to open OpenEPDjson](https://app.asana.com/0/1203527467850668/1208724939366293/f)