### PR TITLE
build: bump `actions/upload-artifact` from v3 to v4

### DIFF
--- a/.github/workflows/build-and-publish-wheel.yml
+++ b/.github/workflows/build-and-publish-wheel.yml
@@ -48,7 +48,7 @@ jobs:
           export POETRY_REPOSITORIES_PRIVATE_URL="${{ secrets.pypi_private_url }}"
           make private-publish
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist/*

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -50,7 +50,7 @@ jobs:
           cat meta/new-changelog.md >> "$GITHUB_OUTPUT"
           echo "$EOF" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bump-meta
           path: meta/*


### PR DESCRIPTION
This action is no longer available for use. See [this deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).