### PR TITLE
Update openEPD link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ including uniqueness of organizations/plants, precise PCR references, and dated 
 The openEPD format is **extensible**. Standard extensions exist for concrete products, and for
 documenting supply-chain specific data.
 
-[Read More about OpenEPD format here](https://www.buildingtransparency.org/programs/openepd/).
+[Read More about OpenEPD format here](https://www.open-epd-forum.org).
 
 ## Usage
 


### PR DESCRIPTION
# Update openEPD link in README

## Problem

The current link to openEPD ([https://www.buildingtransparency.org/programs/openepd/](https://www.buildingtransparency.org/programs/openepd/)) returns a 404 error.

## Solution

Updated the link to the correct site: [https://www.open-epd-forum.org](https://www.open-epd-forum.org)

## Verification

Navigated through [https://www.buildingtransparency.org/programs](https://www.buildingtransparency.org/programs) to the openEPD section, where the "Learn More" button redirects to the new URL.