### PR TITLE
 Add Create and Edit Methods for Multiple APIs

### DIFF
--- a/src/openepd/api/org/__init__.py
+++ b/src/openepd/api/org/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/src/openepd/api/org/sync_api.py
+++ b/src/openepd/api/org/sync_api.py
@@ -1,0 +1,79 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from typing import Literal, overload
+
+from requests import Response
+
+from openepd.api.base_sync_client import BaseApiMethodGroup
+from openepd.api.utils import encode_path_param
+from openepd.model.org import Org, OrgRef
+
+
+class OrgApi(BaseApiMethodGroup):
+    """API methods for Orgs."""
+
+    @overload
+    def create(self, to_create: Org, with_response: Literal[True]) -> tuple[OrgRef, Response]: ...
+
+    @overload
+    def create(self, to_create: Org, with_response: Literal[False] = False) -> OrgRef: ...
+
+    def create(self, to_create: Org, with_response: bool = False) -> OrgRef | tuple[OrgRef, Response]:
+        """
+        Create a new organization.
+
+        :param to_create: Organization to create
+        :param with_response: if True, return a tuple of (OrgRef, Response), otherwise return only OrgRef
+        :return: Organization reference or Organization reference with HTTP Response object depending on parameter
+        :raise ValidationError: if given object Org is invalid
+        """
+        response = self._client.do_request("post", "/orgs", json=to_create.to_serializable())
+        content = response.json()
+        ref = OrgRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref
+
+    @overload
+    def edit(self, to_edit: Org, with_response: Literal[True]) -> tuple[OrgRef, Response]: ...
+
+    @overload
+    def edit(self, to_edit: Org, with_response: Literal[False] = False) -> OrgRef: ...
+
+    def edit(self, to_edit: Org, with_response: bool = False) -> OrgRef | tuple[OrgRef, Response]:
+        """
+        Edit an organization.
+
+        :param to_edit: Organization to edit
+        :param with_response: if True, return a tuple of (OrgRef, Response), otherwise return only Org
+        :return: Organization reference or Organization reference with HTTP Response object depending on parameter
+        :raise ValueError: if the organization web_domain is not set
+        """
+        entity_id = to_edit.web_domain
+        if not entity_id:
+            msg = "The organization web_domain must be set to edit an organization."
+            raise ValueError(msg)
+        response = self._client.do_request(
+            "put",
+            f"/orgs/{encode_path_param(entity_id)}",
+            json=to_edit.to_serializable(exclude_unset=True, exclude_defaults=True, by_alias=True),
+        )
+        response.raise_for_status()
+        content = response.json()
+        ref = OrgRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref

--- a/src/openepd/api/plant/__init__.py
+++ b/src/openepd/api/plant/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/src/openepd/api/plant/sync_api.py
+++ b/src/openepd/api/plant/sync_api.py
@@ -1,0 +1,79 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from typing import Literal, overload
+
+from requests import Response
+
+from openepd.api.base_sync_client import BaseApiMethodGroup
+from openepd.api.utils import encode_path_param
+from openepd.model.org import Plant, PlantRef
+
+
+class PlantApi(BaseApiMethodGroup):
+    """API methods for Plants."""
+
+    @overload
+    def create(self, to_create: Plant, with_response: Literal[True]) -> tuple[PlantRef, Response]: ...
+
+    @overload
+    def create(self, to_create: Plant, with_response: Literal[False] = False) -> PlantRef: ...
+
+    def create(self, to_create: Plant, with_response: bool = False) -> PlantRef | tuple[PlantRef, Response]:
+        """
+        Create a new plant.
+
+        :param to_create: Plant to create
+        :param with_response: if True, return a tuple of (PlantRef, Response), otherwise return only PlantRef
+        :return: Plant reference or Plant reference with HTTP Response object depending on parameter
+        :raise ValidationError: if given object Plant is invalid
+        """
+        response = self._client.do_request("post", "/plants", json=to_create.to_serializable())
+        content = response.json()
+        ref = PlantRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref
+
+    @overload
+    def edit(self, to_edit: Plant, with_response: Literal[True]) -> tuple[PlantRef, Response]: ...
+
+    @overload
+    def edit(self, to_edit: Plant, with_response: Literal[False] = False) -> PlantRef: ...
+
+    def edit(self, to_edit: Plant, with_response: bool = False) -> PlantRef | tuple[PlantRef, Response]:
+        """
+        Edit a plant.
+
+        :param to_edit: Plant to edit
+        :param with_response: if True, return a tuple of (PlantRef, Response), otherwise return only PlantRef
+        :return: Plant reference or Plant reference with HTTP Response object depending on parameter
+        :raise ValueError: if the plant ID is not set
+        """
+        entity_id = to_edit.id
+        if not entity_id:
+            msg = "The plant ID must be set to edit a plant."
+            raise ValueError(msg)
+        response = self._client.do_request(
+            "put",
+            f"/plants/{encode_path_param(entity_id)}",
+            json=to_edit.to_serializable(exclude_unset=True, exclude_defaults=True, by_alias=True),
+        )
+        response.raise_for_status()
+        content = response.json()
+        ref = PlantRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref

--- a/src/openepd/api/standard/__init__.py
+++ b/src/openepd/api/standard/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/src/openepd/api/standard/sync_api.py
+++ b/src/openepd/api/standard/sync_api.py
@@ -1,0 +1,79 @@
+#
+#  Copyright 2025 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from typing import Literal, overload
+
+from requests import Response
+
+from openepd.api.base_sync_client import BaseApiMethodGroup
+from openepd.api.utils import encode_path_param
+from openepd.model.standard import Standard, StandardRef
+
+
+class StandardApi(BaseApiMethodGroup):
+    """API methods for Standards."""
+
+    @overload
+    def create(self, to_create: Standard, with_response: Literal[True]) -> tuple[StandardRef, Response]: ...
+
+    @overload
+    def create(self, to_create: Standard, with_response: Literal[False] = False) -> StandardRef: ...
+
+    def create(self, to_create: Standard, with_response: bool = False) -> StandardRef | tuple[StandardRef, Response]:
+        """
+        Create a new standard.
+
+        :param to_create: Standard to create
+        :param with_response: if True, return a tuple of (StandardRef, Response), otherwise return only StandardRef
+        :return: Standard reference or Standard reference with HTTP Response object depending on parameter
+        :raise ValidationError: if given object Standard is invalid
+        """
+        response = self._client.do_request("post", "/standards", json=to_create.to_serializable())
+        content = response.json()
+        ref = StandardRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref
+
+    @overload
+    def edit(self, to_edit: Standard, with_response: Literal[True]) -> tuple[StandardRef, Response]: ...
+
+    @overload
+    def edit(self, to_edit: Standard, with_response: Literal[False] = False) -> StandardRef: ...
+
+    def edit(self, to_edit: Standard, with_response: bool = False) -> StandardRef | tuple[StandardRef, Response]:
+        """
+        Edit a standard.
+
+        :param to_edit: Standard to edit
+        :param with_response: if True, return a tuple of (StandardRef, Response), otherwise return only StandardRef
+        :return: Standard reference or Standard reference with HTTP Response object depending on parameter
+        :raise ValueError: if the standard short_name is not set
+        """
+        entity_id = to_edit.short_name
+        if not entity_id:
+            msg = "The standard short_name must be set to edit a standard."
+            raise ValueError(msg)
+        response = self._client.do_request(
+            "put",
+            f"/standards/{encode_path_param(entity_id)}",
+            json=to_edit.to_serializable(exclude_unset=True, exclude_defaults=True, by_alias=True),
+        )
+        response.raise_for_status()
+        content = response.json()
+        ref = StandardRef.parse_obj(content)
+        if with_response:
+            return ref, response
+        return ref

--- a/src/openepd/api/sync_client.py
+++ b/src/openepd/api/sync_client.py
@@ -22,7 +22,10 @@ from openepd.api.average_dataset.industry_epd_sync_api import IndustryEpdApi
 from openepd.api.base_sync_client import SyncHttpClient, TokenAuth
 from openepd.api.category.sync_api import CategoryApi
 from openepd.api.epd.sync_api import EpdApi
+from openepd.api.org.sync_api import OrgApi
 from openepd.api.pcr.sync_api import PcrApi
+from openepd.api.plant.sync_api import PlantApi
+from openepd.api.standard.sync_api import StandardApi
 
 
 class OpenEpdApiClientSync:
@@ -41,6 +44,9 @@ class OpenEpdApiClientSync:
         self._http_client = SyncHttpClient(base_url, auth=auth, **kwargs)
         self.__epd_api: EpdApi | None = None
         self.__pcr_api: PcrApi | None = None
+        self.__org_api: OrgApi | None = None
+        self.__plant_api: PlantApi | None = None
+        self.__standard_api: StandardApi | None = None
         self.__category_api: CategoryApi | None = None
         self.__generic_estimate_api: GenericEstimateApi | None = None
         self.__industry_epd_api: IndustryEpdApi | None = None
@@ -58,6 +64,27 @@ class OpenEpdApiClientSync:
         if self.__pcr_api is None:
             self.__pcr_api = PcrApi(self._http_client)
         return self.__pcr_api
+
+    @property
+    def orgs(self) -> OrgApi:
+        """Get the Org API."""
+        if self.__org_api is None:
+            self.__org_api = OrgApi(self._http_client)
+        return self.__org_api
+
+    @property
+    def plants(self) -> PlantApi:
+        """Get the Plant API."""
+        if self.__plant_api is None:
+            self.__plant_api = PlantApi(self._http_client)
+        return self.__plant_api
+
+    @property
+    def standards(self) -> StandardApi:
+        """Get the Standard API."""
+        if self.__standard_api is None:
+            self.__standard_api = StandardApi(self._http_client)
+        return self.__standard_api
 
     @property
     def categories(self) -> CategoryApi:


### PR DESCRIPTION
This pull request introduces enhancements to several API modules:

- **PcrApi**:  
  - Added an `edit` method with support for an optional response.

- **Org, Plant, and Standard APIs**:  
  - Implemented both `create` and `edit` methods to support full CRUD operations.
