### PR TITLE
Improve pydantic and openapi compatibility

### DIFF
--- a/src/openepd/model/org.py
+++ b/src/openepd/model/org.py
@@ -126,8 +126,7 @@ class Plant(PlantRef, WithAttachmentsMixin, WithAltIdsMixin):
         default=None,
         description="(deprecated) Plus code (aka Open Location Code) of plant's location",
         json_schema_extra={
-            "deprecated": "Pluscode field is deprecated. If users need a pluscode they can obtain it from "
-            "`id` like this: `id.spit('.', maxsplit=1)[0]`",
+            "deprecated": True,
         },
     )
     latitude: float | None = pydantic.Field(

--- a/src/openepd/model/versioning.py
+++ b/src/openepd/model/versioning.py
@@ -30,8 +30,11 @@ class WithExtVersionMixin(ABC, pydantic.BaseModel):
         """Set the default value for the ext_version field from _EXT_VERSION class var."""
         super().__init_subclass__()
         if hasattr(cls, "_EXT_VERSION"):
-            cls.model_fields["ext_version"].default = cls._EXT_VERSION
-
+            cls.model_fields["ext_version"] = pydantic.Field(
+                description="Extension version",
+                examples=["3.22"],
+                default_factory=lambda: cls._EXT_VERSION
+            )
     # Note: default is set programmatically in __init_subclass__
     ext_version: str | None = pydantic.Field(description="Extension version", examples=["3.22"], default=None)
 


### PR DESCRIPTION
# Content
This PR improves the compability of `openepd` with pydantic v2 and openAPI

## Impacts

The way `_update_schema_extra` was defined is not compatible with recent OpenAPI/Pydantic versions.
The suggested approach works ok but it's super slow to generate the schema (when accessing for e.g. `fastApiUrl/docs`):
![image](https://github.com/user-attachments/assets/aaba923d-185e-4da3-a2f7-66898b820510)

If it was just me I would just remove this `_update_schema_extra` \o/

Maybe you see a better way to do it ?

## Versionning 
We need to use pydantic `default_factory` to instantiate default attribute, otherwise it will raise a `WARNING`.

## Plant
`deprecated` needs to be a `bool` and not a `str`