### PR TITLE
fix: set default for `short_name` to make field optional in Standard …

### DIFF
--- a/src/openepd/model/standard.py
+++ b/src/openepd/model/standard.py
@@ -29,7 +29,8 @@ class StandardRef(BaseOpenEpdSchema):
         description="Reference to this Standard's JSON object",
     )
     short_name: str | None = pydantic.Field(
-        description="Short-form of name of standard.  Must be unique. Case-insensitive"
+        default=None,
+        description="Short-form of name of standard.  Must be unique. Case-insensitive",
     )
 
 


### PR DESCRIPTION
…model

Ensures `short_name` is treated as optional in Pydantic v2 by explicitly setting its default value.