### PR TITLE
fix: enforce full pluscode validation for Plant

### DIFF
--- a/src/openepd/model/org.py
+++ b/src/openepd/model/org.py
@@ -179,6 +179,10 @@ class Plant(PlantRef, WithAttachmentsMixin, WithAltIdsMixin):
             msg = "Incorrect pluscode for plant"
             raise ValueError(msg)
 
+        if not openlocationcode.isFull(pluscode):
+            msg = "Passed Open Location Code is not a valid full code"
+            raise ValueError(msg)
+
         if not web_domain:
             msg = "Incorrect web_domain for plant"
             raise ValueError(msg)

--- a/src/openepd/model/tests/test_plant.py
+++ b/src/openepd/model/tests/test_plant.py
@@ -30,3 +30,8 @@ class PlantTestCase(unittest.TestCase):
         p = Plant.parse_obj(test_data)
 
         self.assertEqual(p.id, "85644Q4R+3P.cemex.com")
+
+    def test_plant_parse_no_full_pluscode(self):
+        test_data = {"id": "F47F+5W.cemex.com"}
+        with self.assertRaises(ValueError):
+            Plant.parse_obj(test_data)


### PR DESCRIPTION
asana: [Update Error Handling for Invalid Plus Codes in OpenEPD JSON POST Requests](https://app.asana.com/1/654700433662128/project/1205308458277257/task/1210481962946590?focus=true)