### PR TITLE
feat(model): add attachment URL getters to WithAttachmentsMixin

### DIFF
--- a/src/openepd/model/common.py
+++ b/src/openepd/model/common.py
@@ -419,6 +419,30 @@ class WithAttachmentsMixin(pydantic.BaseModel):
         if url is not None:
             self.set_attachment(name, url)
 
+    def get_attachment(self, name: str) -> pydantic.AnyUrl | str | None:
+        """
+        Return the URL of an attachment.
+
+        :param name: name of the attachment to look up.
+        :return: the attachment URL, or ``None`` if no such attachment exists.
+        """
+        if self.attachments is None:
+            return None
+        return self.attachments.get(name)
+
+    def get_attachment_as_string(self, name: str) -> str | None:
+        """
+        Return the URL of an attachment as a string.
+
+        Pydantic v2 ``AnyUrl`` values are not plain strings, so this converts the stored
+        value to its string representation.
+
+        :param name: name of the attachment to look up.
+        :return: the attachment URL as a string, or ``None`` if no such attachment exists.
+        """
+        url = self.get_attachment(name)
+        return str(url) if url else None
+
 
 class WithAltIdsMixin(pydantic.BaseModel):
     """Mixin for objects that can have alt_ids."""

--- a/src/openepd/model/tests/test_attachments.py
+++ b/src/openepd/model/tests/test_attachments.py
@@ -1,0 +1,59 @@
+#
+#  Copyright 2026 by C Change Labs Inc. www.c-change-labs.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from typing import Final
+import unittest
+
+import pydantic as pyd
+
+from openepd.model.common import WithAttachmentsMixin
+
+SAMPLE_URL: Final[str] = "https://example.com/epd"
+
+
+class WithAttachmentsMixinTestCase(unittest.TestCase):
+    def test_get_attachment_returns_stored_url(self) -> None:
+        url = SAMPLE_URL
+        model = WithAttachmentsMixin(attachments={"EPD": url})
+
+        attachment = model.get_attachment("EPD")
+
+        self.assertIsNotNone(attachment)
+        self.assertEqual(str(attachment), url)
+
+    def test_get_attachment_as_string_returns_stored_url(self) -> None:
+        url = SAMPLE_URL
+        model = WithAttachmentsMixin(attachments={"EPD": url})
+
+        self.assertEqual(model.get_attachment_as_string("EPD"), url)
+
+    def test_get_attachment_as_string_converts_anyurl(self) -> None:
+        url_str = SAMPLE_URL
+        any_url = pyd.TypeAdapter(pyd.AnyUrl).validate_python(url_str)
+        model = WithAttachmentsMixin(attachments={"EPD": any_url})
+
+        self.assertEqual(model.get_attachment_as_string("EPD"), url_str)
+
+    def test_attachment_accessors_return_none_when_attachment_is_missing(self) -> None:
+        model = WithAttachmentsMixin(attachments={"EPD": SAMPLE_URL})
+
+        self.assertIsNone(model.get_attachment("Datasheet"))
+        self.assertIsNone(model.get_attachment_as_string("Datasheet"))
+
+    def test_attachment_accessors_return_none_when_attachments_are_unset(self) -> None:
+        model = WithAttachmentsMixin()
+
+        self.assertIsNone(model.get_attachment("EPD"))
+        self.assertIsNone(model.get_attachment_as_string("EPD"))


### PR DESCRIPTION
Add `get_attachment` and `get_attachment_as_string` to reduce friction when retrieving attachment URLs from `WithAttachmentsMixin`.

Also add unit tests covering:
- returning stored attachment URLs
- string conversion for `AnyUrl` values
- `None` behavior for missing or unset attachments